### PR TITLE
PATCH: real root path to enabling module web extensions

### DIFF
--- a/Core/HandlerMgr.py
+++ b/Core/HandlerMgr.py
@@ -36,9 +36,11 @@ class HandlerMgr( object ):
         continue
       try:
         modFile, modPath, desc = imp.find_module( extName )
+	#to match in the real root path to enabling module web extensions (static, templates...)
+	realModPath = os.path.realpath( modPath )
       except ImportError:
         continue
-      staticPath = os.path.join( modPath, "WebApp", dirName )
+      staticPath = os.path.join( realModPath, "WebApp", dirName )
       if os.path.isdir( staticPath ):
         pathList.append( staticPath )
     #Add WebAppDirac to the end


### PR DESCRIPTION
I saw in dirac.egi.eu VMDIRAC module in new web was not loaded:
2015-10-08 08:26:51 UTC WebApp/Routing   INFO: Found handler WebApp.handler.VMDiracHandler
so the VM extension is correctly obtained

WARNING:tornado.general:403 GET /DIRAC/s:EGI-Production/g:breakseq_cloud/static/VMDIRAC/VMDirac/classes/VMDirac.js (85.58.20.119): /opt/dirac/pro/VMDIRAC/WebApp/static/VMDIRAC/VMDirac/classes/VMDirac.js is not in root static directory
2015-10-08 08:28:45 UTC WebApp/Web   WARN: 403 GET /DIRAC/s:EGI-Production/g:breakseq_cloud/static/VMDIRAC/VMDirac/classes/VMDirac.js (85.58.20.119) 1.20ms

403 is a forbiden error for this file.

I just do and test this hotpatch to take real paths, and it is working
