### PR TITLE
FileCatalogHandler, fix crash saving list of lfns

### DIFF
--- a/WebApp/handler/FileCatalogHandler.py
+++ b/WebApp/handler/FileCatalogHandler.py
@@ -332,9 +332,8 @@ class FileCatalogHandler( WebHandler ):
     retStrLines = []
 
     if len(result)>0:
-      for key , value in result.items() :
-        for fileName in value:
-          retStrLines.append(key+"/"+fileName)
+      for fileName in result:
+        retStrLines.append(fileName)
 
     strData = "\n".join(retStrLines)
 


### PR DESCRIPTION
There was an AttributeError exception, because there is no dict in the result['Value'] from findFilesByMetadata, because it just returns a list of lfns