### PR TITLE
Allow dot in group names

### DIFF
--- a/Core/HandlerMgr.py
+++ b/Core/HandlerMgr.py
@@ -20,8 +20,8 @@ class HandlerMgr( object ):
     self.__baseURL = baseURL.strip( "/" )
     self.__routes = []
     self.__handlers = []
-    self.__setupGroupRE = r"(?:/s:([\w-]*)/g:([\w-]*))?"
-    self.__shySetupGroupRE = r"(?:/s:(?:[\w-]*)/g:(?:[\w-]*))?"
+    self.__setupGroupRE = r"(?:/s:([\w-]*)/g:([\w.-]*))?"
+    self.__shySetupGroupRE = r"(?:/s:(?:[\w-]*)/g:(?:[\w.-]*))?"
     self.log = gLogger.getSubLogger( "Routing" )
 
   def getPaths( self, dirName ):


### PR DESCRIPTION
This allows group names containing dots to work correctly with the web interface rather than returning a 404 when switching to such a group. This is the fix for the query posted by @marianne013 on the diracgrid-forum about a month ago which received no response.

Regards,
Simon
