### PR TITLE
Fix Restart button on SysAdministration toolbar

### DIFF
--- a/WebApp/static/DIRAC/SystemAdministration/classes/SystemAdministration.js
+++ b/WebApp/static/DIRAC/SystemAdministration/classes/SystemAdministration.js
@@ -1271,7 +1271,7 @@ Ext.define('DIRAC.SystemAdministration.classes.SystemAdministration', {
             if (oElems[i].checked) {
               iNumberSelected++;
               var oVal = oElems[i].value.split("|||");
-              var sTarget = oVal[0] + ' @ ' + oVal[1];
+              var sTarget = oVal[0] + '@' + oVal[1];
               if (!oParams[sTarget]) {
                 oParams[sTarget] = [];
               }


### PR DESCRIPTION
This fixes a bug we found where the Restart button on the System Administrator (component) toolbar doesn't work (and possibly the other actions too), but right clicking on an individual item does. This is caused by an additional space on the end of the component name when the request is sent to the server.

Regards,
Simon
