### PR TITLE
To handle UTC datetime more correctly in DiracTimeSearchPanel.js

### DIFF
--- a/WebApp/static/core/js/utils/DiracTimeSearchPanel.js
+++ b/WebApp/static/core/js/utils/DiracTimeSearchPanel.js
@@ -200,13 +200,12 @@ Ext.define('Ext.dirac.utils.DiracTimeSearchPanel', {
 
         if ((iSpanValue != null) && (iSpanValue != 5)) {
 
-          var oNowJs = new Date();
+          var oLocalNowJs = new Date();
+          var oNowJs = Ext.Date.add(oLocalNowJs, Ext.Date.MINUTE, oLocalNowJs.getTimezoneOffset());
           var oBegin = null;
 
           switch (iSpanValue) {
             case 1 :
-              var utcHours = oNowJs.getUTCHours();
-              oNowJs.setHours(utcHours);
               oBegin = Ext.Date.add(oNowJs, Ext.Date.HOUR, -1);
               break;
             case 2 :


### PR DESCRIPTION
Dear developers,

as I discussed in DiracGrid Forum, I make the modification of DiracTimeSearchPanel.js
to handle UTC time more correctly.
There, similar treatment of UTC translation in case 1 'last hour', is embedded.
But, new one affects to all the cases.

Best regards,
K.Hayasaka