### PR TITLE
Prevent XSS

### DIFF
--- a/WebApp/handler/RootHandler.py
+++ b/WebApp/handler/RootHandler.py
@@ -5,6 +5,11 @@ from WebAppDIRAC.Lib import Conf
 from WebAppDIRAC.Lib.WebHandler import WebHandler, WErr
 import re
 
+def xss_filter(text):
+  cleanr =re.compile('<.*?>')
+  cleantext = re.sub(cleanr,'', text)
+  return cleantext
+
 class RootHandler(WebHandler):
 
   AUTH_PROPS = "all"
@@ -45,11 +50,11 @@ class RootHandler(WebHandler):
 
     url_state = ""
     if self.request.arguments.has_key("url_state") and len(self.request.arguments["url_state"][0]) > 0:
-      url_state = self.request.arguments["url_state"][0]
+      url_state = xss_filter( self.request.arguments["url_state"][0] )
 
     view_name = Conf.getTheme()
     if self.request.arguments.has_key("view") and len(self.request.arguments["view"][0]) > 0:
-      view_name = self.request.arguments["view"][0]
+      view_name = xss_filter( self.request.arguments["view"][0] )
 
     theme_name = "ext-all-gray"
     if self.request.arguments.has_key("theme") and len(self.request.arguments["theme"][0]) > 0:
@@ -60,7 +65,7 @@ class RootHandler(WebHandler):
 
     open_app = ""
     if self.request.arguments.has_key("open_app") and len(self.request.arguments["open_app"][0]) > 0:
-      open_app = self.request.arguments["open_app"][0].strip()
+      open_app = xss_filter( self.request.arguments["open_app"][0].strip() )
 
     icon = data[ 'baseURL' ] + Conf.getIcon()
 


### PR DESCRIPTION
After a little bit of investigation I found that the dirac web application is vulnerable to [reflected cross site scripting attacks (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting).

XSS is a very common vulnerability which is often used to hijack a user's session.

The following parameters were affected: `url_state`, `view`, `open_app`
Here is a screenshot that confirms the existence of the vulnerability:
![xss2](https://cloud.githubusercontent.com/assets/8127545/17365113/913fa41a-5984-11e6-81cc-d3c1fa401eda.png)


I added a filter that removes the `<` `>` tags using regular expressions.
Feel free to discuss the changes.
