### PR TITLE
Removed RequestMonitor

### DIFF
--- a/WebApp/web.cfg
+++ b/WebApp/web.cfg
@@ -27,7 +27,7 @@ WebApp
       System Administration = DIRAC.SystemAdministration
       Activity Monitor = DIRAC.ActivityMonitor
       Transformation Monitor = DIRAC.TransformationMonitor
-      Request Monitor = DIRAC.RequestMonitor
+      #Request Monitor = DIRAC.RequestMonitor
       Pilot Summary = DIRAC.PilotSummary
       Resource Summary = DIRAC.ResourceSummary
       Site Summary = DIRAC.SiteSummary


### PR DESCRIPTION
This PR simply comments out the RequestMonitor web page. The reason is that it is a "dangerous" Web App: though that one can potentially launch extremely heavy requests to RequestDB. 

I am totally aware that there are much better ways: the problem is not the App itself but what you can do with the DB (and with the RequestManager service), so this is just a quick'n dirty solution. I have created an issue in https://github.com/DIRACGrid/DIRAC/issues/3581