### PR TITLE
[v3r1p4] Don't filter available JobGroups

### DIFF
--- a/WebApp/handler/JobMonitorHandler.py
+++ b/WebApp/handler/JobMonitorHandler.py
@@ -104,7 +104,7 @@ class JobMonitorHandler( WebHandler ):
           prods = result["Value"]
           if len( prods ) > 0:
             prods.sort( reverse = True )
-            prod = [ [ i ] for i in prods if i.startswith('00')]
+            prod = [ [ i ] for i in prods ]
           else:
             prod = [["Nothing to display"]]
         else:


### PR DESCRIPTION
Hi,

The filter requiring JobGroups to start with "00" seems to LHCb specific... I couldn't find any requirement that job groups should be numeric or follow a pattern. This patch removes the filter, which makes other user defined JobGroups available in the web interface JobMonifor filter box.

Regards,
Simon
