### PR TITLE
[v3r1] Fix selection bug for accounting/monitoring left panel

### DIFF
--- a/WebApp/handler/AccountingHandler.py
+++ b/WebApp/handler/AccountingHandler.py
@@ -11,6 +11,8 @@ import datetime
 
 from hashlib import md5
 
+import json
+
 class AccountingHandler( WebHandler ):
 
   AUTH_PROPS = "all"
@@ -148,7 +150,10 @@ class AccountingHandler( WebHandler ):
         extraParams[ k[3:] ] = pD[ k ]
     # Listify the rest
     for selName in pD:
-      pD[ selName ] = List.fromChar( pD[ selName ], "," )
+      if selName == 'grouping':
+        pD[ selName ] = [ pD[ selName ] ]
+      else:
+        pD[ selName ] = json.loads( pD[ selName ] )
 
     return S_OK( ( typeName, reportName, start, end, pD, grouping, extraParams ) )
 

--- a/WebApp/handler/MonitoringHandler.py
+++ b/WebApp/handler/MonitoringHandler.py
@@ -11,6 +11,8 @@ import datetime
 
 from hashlib import md5
 
+import json
+
 class MonitoringHandler( WebHandler ):
 
   AUTH_PROPS = "authenticated"
@@ -148,7 +150,10 @@ class MonitoringHandler( WebHandler ):
         extraParams[ k[3:] ] = pD[ k ]
     # Listify the rest
     for selName in pD:
-      pD[ selName ] = List.fromChar( pD[ selName ], "," )
+      if selName == 'grouping':
+        pD[ selName ] = [ pD[ selName ] ]
+      else:
+        pD[ selName ] = json.loads( pD[ selName ] )
 
     return S_OK( ( typeName, reportName, start, end, pD, grouping, extraParams ) )
 

--- a/WebApp/static/DIRAC/SystemAdministration/classes/SystemAdministration.js
+++ b/WebApp/static/DIRAC/SystemAdministration/classes/SystemAdministration.js
@@ -1574,8 +1574,8 @@ Ext.define('DIRAC.SystemAdministration.classes.SystemAdministration', {
 
                 }
 
-                var sUsers = ((oUsers.isInverseSelection()) ? oUsers.getInverseSelection() : oUsers.getValue().join(","));
-                var sGroups = ((oGroups.isInverseSelection()) ? oGroups.getInverseSelection() : oGroups.getValue().join(","));
+                var sUsers = ((oUsers.isInverseSelection()) ? oUsers.getInverseSelection() : oUsers.getValue()).join(",");
+                var sGroups = ((oGroups.isInverseSelection()) ? oGroups.getInverseSelection() : oGroups.getValue()).join(",");
 
                 if ((Ext.util.Format.trim(sUsers) == "") && (Ext.util.Format.trim(sGroups) == "")) {
 

--- a/WebApp/static/core/js/utils/DiracBaseSelector.js
+++ b/WebApp/static/core/js/utils/DiracBaseSelector.js
@@ -622,10 +622,7 @@ Ext.define('Ext.dirac.utils.DiracBaseSelector', {
             Ext.merge(extraParams, timeSearchData);
           }
           for (var i in me.cmbSelectors) {
-            var param = (me.cmbSelectors[i].isInverseSelection()) ? me.cmbSelectors[i].getInverseSelection().split(",") : me.cmbSelectors[i].getValue();
-            // var param = (me.cmbSelectors[i].isInverseSelection()) ?
-            // me.cmbSelectors[i].getInverseSelection() :
-            // me.cmbSelectors[i].getValue();
+            var param = (me.cmbSelectors[i].isInverseSelection()) ? me.cmbSelectors[i].getInverseSelection() : me.cmbSelectors[i].getValue();
             if (param.length != 0) {
               extraParams[i] = Ext.JSON.encode(param);
             }

--- a/WebApp/static/core/js/utils/DiracBoxSelect.js
+++ b/WebApp/static/core/js/utils/DiracBoxSelect.js
@@ -353,14 +353,7 @@ Ext.define('Ext.dirac.utils.DiracBoxSelect', {
 
       },
 
-      getInverseSelection : function(sSeparator) {
-
-        var s = "";
-
-        if (!sSeparator)
-          s = ",";
-        else
-          s = sSeparator;
+      getInverseSelection : function() {
 
         var me = this;
 
@@ -374,7 +367,7 @@ Ext.define('Ext.dirac.utils.DiracBoxSelect', {
         for (var i = 0; i < records.getCount(); i++)
             oInverseValues.push(records.getAt(i).get(me.valueField));
 
-        return oInverseValues.join(s);
+        return oInverseValues;
 
       },
 

--- a/WebApp/static/core/js/utils/PlotView.js
+++ b/WebApp/static/core/js/utils/PlotView.js
@@ -782,7 +782,8 @@ Ext.define('Ext.dirac.utils.PlotView', {
           if (oCondItem.getValue().length != 0) {
 
             if (sIntention == "show_plot") {
-              oParams["_" + oCondItem.getName()] = ((oCondItem.isInverseSelection()) ? oCondItem.getInverseSelection() : oCondItem.getValue().join(","));
+              param = (oCondItem.isInverseSelection()) ? oCondItem.getInverseSelection() : oCondItem.getValue();
+              oParams["_" + oCondItem.getName()] = Ext.JSON.encode(param);
             } else if (sIntention == "save_state") {
               oParams["_" + oCondItem.getName()] = [((oCondItem.isInverseSelection()) ? 1 : 0), oCondItem.getValue().join(",")];
             }


### PR DESCRIPTION
This bug was first found when plotting with specific selection. When I select "Application Status" with something like

    RuntimeError("job.py Exited With Status 1",)

there are just no data displayed, which I was certain that data must exist.
I found that the comma result in this. This status will be splitted into two values by the comma

    RuntimeError("job.py Exited With Status 1"
    )

Then I checked situation in JobMonitoring and it just works correctly with json encoding.
So I modify PlotView with similar method.

Also another bug will happen when inverse select on all pages use DiracBaseSelector. It is similar to the above situation when status value includes comma.
