### PR TITLE
[v3r1] Nginx returns user DN not in the standard form

### DIFF
--- a/Lib/WebHandler.py
+++ b/Lib/WebHandler.py
@@ -163,6 +163,10 @@ class WebHandler(tornado.web.RequestHandler):
       headers = self.request.headers
       if headers['X-Scheme'] == "https" and headers['X-Ssl_client_verify'] == 'SUCCESS':
         DN = headers['X-Ssl_client_s_dn']
+        if not DN.startswith('/'):
+          items = DN.split(',')
+          items.reverse()
+          DN = '/' + '/'.join(items)
         self.__credDict['DN'] = DN
         self.__credDict['issuer'] = headers['X-Ssl_client_i_dn']
         result = Registry.getUsernameForDN(DN)


### PR DESCRIPTION
Nginx (sometimes ?) returns the user DN not in the standard form with fields separated by slashes.