### PR TITLE
[v4r0] Add warning on launch if running with HTTP

### DIFF
--- a/WebApp/handler/RootHandler.py
+++ b/WebApp/handler/RootHandler.py
@@ -108,4 +108,5 @@ class RootHandler(WebHandler):
                 credentials=data['user'], title=Conf.getTitle(),
                 theme=theme_name, root_url=Conf.rootURL(), view=view_name,
                 open_app=open_app, debug_level=level, welcome=welcome,
-                backgroundImage=background, logo=logo, bugReportURL=Conf.bugReportURL())
+                backgroundImage=background, logo=logo, bugReportURL=Conf.bugReportURL(),
+                http_port=Conf.HTTPPort(), https_port=Conf.HTTPSPort())

--- a/WebApp/static/core/js/core/CommonFunctions.js
+++ b/WebApp/static/core/js/core/CommonFunctions.js
@@ -191,7 +191,7 @@ Ext.define('Ext.dirac.core.CommonFunctions', {
         }
         return sVal;
       },
-      msg : function(type, message) {
+      msg : function(type, message, autoClose = null) {
         var me = this;
 
         if (message == null)
@@ -212,6 +212,7 @@ Ext.define('Ext.dirac.core.CommonFunctions', {
 
           case "Notification" :
             config = {
+              autoClose : autoClose === null ? true : autoClose,
               title : 'Notification',
               position : 'tl',
               manager : (GLOBAL.APP.MAIN_VIEW ? GLOBAL.APP.MAIN_VIEW.Id : null),
@@ -224,7 +225,7 @@ Ext.define('Ext.dirac.core.CommonFunctions', {
 
           case "Error Notification" :
             config = {
-              autoClose : false,
+              autoClose : autoClose === null ? false : autoClose,
               title : 'Error Notification',
               position : 'tl',
               manager : (GLOBAL.APP.MAIN_VIEW ? GLOBAL.APP.MAIN_VIEW.Id : null),
@@ -237,6 +238,7 @@ Ext.define('Ext.dirac.core.CommonFunctions', {
 
           case "info" :
             config = {
+              autoClose : autoClose === null ? true : autoClose,
               title : 'Notification',
               position : 'tl',
               manager : (GLOBAL.APP.MAIN_VIEW ? GLOBAL.APP.MAIN_VIEW.Id : null),
@@ -249,7 +251,7 @@ Ext.define('Ext.dirac.core.CommonFunctions', {
 
           case "Error" :
             config = {
-              autoClose : false,
+              autoClose : autoClose === null ? false : autoClose,
               title : 'Error Notification',
               position : 'tl',
               manager : (GLOBAL.APP.MAIN_VIEW ? GLOBAL.APP.MAIN_VIEW.Id : null),
@@ -262,7 +264,7 @@ Ext.define('Ext.dirac.core.CommonFunctions', {
 
           default :
             config = {
-              autoClose : false,
+              autoClose : autoClose === null ? false : autoClose,
               title : 'Error Notification',
               position : 'tl',
               manager : (GLOBAL.APP.MAIN_VIEW ? GLOBAL.APP.MAIN_VIEW.Id : null),

--- a/WebApp/template/root.tpl
+++ b/WebApp/template/root.tpl
@@ -103,6 +103,7 @@
             },1000);
             if (location.protocol === 'http:') {
               var https_url = location.href.replace('http:', 'https:');
+              https_url = https_url.replace(":{{ http_port }}/", ":{{ https_port }}/");
               Ext.dirac.system_info.msg(
                 "Notification",
                 'Running without authentication, did you mean: '+

--- a/WebApp/template/root.tpl
+++ b/WebApp/template/root.tpl
@@ -101,6 +101,15 @@
               Ext.get("app-dirac-loading").hide();
               Ext.get("app-dirac-loading-msg").setHtml("Loading module. Please wait ...");
             },1000);
+            if (location.protocol === 'http:') {
+              var https_url = location.href.replace('http:', 'https:');
+              Ext.dirac.system_info.msg(
+                "Notification",
+                'Running without authentication, did you mean: '+
+                '<a href="'+https_url+'">'+https_url+'</a>?',
+                false
+              );
+            };
           });
       {% else %}
           var GLOBAL = {};


### PR DESCRIPTION
I've seen many people struggle to understand the `Operation failed: Not a registered user.` error message when accidentally connecting via HTTP instead of HTTPS. I think it would be useful to suggest the HTTPS URL when this happens.

BEGINRELEASENOTES
NEW Show warning on launch if running with HTTP
ENDRELEASENOTES
