### PR TITLE
Fix a bug in making extension name

### DIFF
--- a/Core/HandlerMgr.py
+++ b/Core/HandlerMgr.py
@@ -35,7 +35,7 @@ class HandlerMgr(object):
     """
     pathList = []
     for extName in CSGlobals.getCSExtensions():
-      if extName.rfind("DIRAC") != len(extName) - 5:
+      if not extName.endswith('DIRAC'):
         extName = "%sDIRAC" % extName
       if extName == "WebAppDIRAC":
         continue


### PR DESCRIPTION

BEGINRELEASENOTES

FIX: When the length of extension name is 4, there is a problem to add "DIRAC" as an end.   

ENDRELEASENOTES
