### PR TITLE
[v4r0] WebApp starts in production mode instead of development by default

### DIFF
--- a/Lib/Conf.py
+++ b/Lib/Conf.py
@@ -31,7 +31,7 @@ def getTitle():
 
 
 def devMode():
-  return getCSValue("DevelopMode", True)
+  return getCSValue("DevelopMode", False)
 
 
 def rootURL():


### PR DESCRIPTION

BEGINRELEASENOTES

Conf:
CHANGE: WebApp starts in production mode by default

ENDRELEASENOTES
