### PR TITLE
"Application Wizard" typo in desktop title and tab

### DIFF
--- a/WebApp/static/DIRAC/ApplicationWizard/classes/ApplicationWizard.js
+++ b/WebApp/static/DIRAC/ApplicationWizard/classes/ApplicationWizard.js
@@ -28,7 +28,7 @@ Ext.define('DIRAC.ApplicationWizard.classes.ApplicationWizard', {
 
         if (GLOBAL.VIEW_ID == "desktop") {
 
-          me.launcher.title = "Application Wizzard";
+          me.launcher.title = "Application Wizard";
           me.launcher.maximized = false;
 
           var oDimensions = GLOBAL.APP.MAIN_VIEW.getViewMainDimensions();
@@ -43,7 +43,7 @@ Ext.define('DIRAC.ApplicationWizard.classes.ApplicationWizard', {
 
         if (GLOBAL.VIEW_ID == "tabs") {
 
-          me.launcher.title = "Application Wizzard";
+          me.launcher.title = "Application Wizard";
           me.launcher.maximized = false;
 
           var oDimensions = GLOBAL.APP.MAIN_VIEW.getViewMainDimensions();


### PR DESCRIPTION
BEGINRELEASENOTES

FIX: tab/title spelling fix for Application Wizard

ENDRELEASENOTES
