### PR TITLE
[v4r1] Add option ApplicationList to LaunchPad

### DIFF
--- a/WebApp/handler/JobLaunchpadHandler.py
+++ b/WebApp/handler/JobLaunchpadHandler.py
@@ -137,7 +137,7 @@ class JobLaunchpadHandler(WebHandler):
     predefinedSets = {}
     launchpadSections = obj.getSections("Launchpad")
     if launchpadSections['OK']:
-      for section in launchpadSections["Value"]:
+      for section in obj.getValue("Launchpad/ApplicationList", launchpadSections["Value"]):
         predefinedSets[section] = {}
         sectionOptions = obj.getOptionsDict("Launchpad/" + section)
         pprint.pprint(sectionOptions)

--- a/WebApp/static/DIRAC/FileCatalog/classes/FileCatalog.js
+++ b/WebApp/static/DIRAC/FileCatalog/classes/FileCatalog.js
@@ -1441,23 +1441,20 @@ Ext.define("DIRAC.FileCatalog.classes.FileCatalog", {
         if (bNot) {
           sSign = "!=";
         } else {
-
           oDropDown.suspendEvents(false);
 
           var oNewStore = new Ext.data.ArrayStore({
-                fields : ['value', 'text'],
-                data : me.__getFieldOptions(oThisBlock.fieldName)
-              });
+            fields: ["value", "text"],
+            data: me.__getFieldOptions(oThisBlock.fieldName)
+          });
 
           switch (sBlockType) {
-
-            case "value" :
+            case "value":
               oDropDown.bindStore(oNewStore);
               break;
-            case "string" :
+            case "string":
               oDropDown.setStore(oNewStore);
               break;
-
           }
 
           oDropDown.collapse();
@@ -1465,7 +1462,6 @@ Ext.define("DIRAC.FileCatalog.classes.FileCatalog", {
 
           oDropDown.resumeEvents();
           me.queryPanel.body.unmask();
-
         }
         break;
       case "meta-gequal-icon":


### PR DESCRIPTION
The `Launchpad` app have predefined sets of values(`Operations/Defaults/Launchpad` in CS). Launchpad handler use it for all VOs, but if some don't want use defaults.. This PR allows to ignore it and use only sets specified in `Operations/<vo>/<setup>/Launchpad/ApplicationList ` option.

BEGINRELEASENOTES

LaunchPad:
NEW: Add option ApplicationList

ENDRELEASENOTES
