### PR TITLE
[v4r0] Hot fix. Rename refreshStore to setStore

### DIFF
--- a/WebApp/static/DIRAC/FileCatalog/classes/FileCatalog.js
+++ b/WebApp/static/DIRAC/FileCatalog/classes/FileCatalog.js
@@ -1309,7 +1309,7 @@ Ext.define('DIRAC.FileCatalog.classes.FileCatalog', {
                         oDropDown.bindStore(oNewStore);
                         break;
                       case "string" :
-                        oDropDown.refreshStore(oNewStore);
+                        oDropDown.setStore(oNewStore);
                         break;
 
                     }
@@ -1350,7 +1350,7 @@ Ext.define('DIRAC.FileCatalog.classes.FileCatalog', {
               oDropDown.bindStore(oNewStore);
               break;
             case "string" :
-              oDropDown.refreshStore(oNewStore);
+              oDropDown.setStore(oNewStore);
               break;
 
           }


### PR DESCRIPTION
This PR fix refreshStore to setStore in FileCatalog.

BEGINRELEASENOTES

*FileCatalog
FIX: fix refreshStore to setStore

ENDRELEASENOTES
