### PR TITLE
[v4r0] SystemAdmin.js: correct dataIndex for Disk column

### DIFF
--- a/WebApp/static/DIRAC/SystemAdministration/classes/SystemAdministration.js
+++ b/WebApp/static/DIRAC/SystemAdministration/classes/SystemAdministration.js
@@ -312,7 +312,7 @@ Ext.define('DIRAC.SystemAdministration.classes.SystemAdministration', {
                     sortable : true
                   }, {
                     align : 'left',
-                    dataIndex : 'Disk',
+                    dataIndex : 'DiskOccupancy',
                     header : 'Disk',
                     sortable : true
                   }, {


### PR DESCRIPTION

BEGINRELEASENOTES

FIX: SystemAdministrator App: correct dataIndex for Disk column so disk occupancy is displayed for each host, fixes #391 

ENDRELEASENOTES
