### PR TITLE
[v4r0] Fixes for various errors and deprecation warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+    "parserOptions": {
+        "ecmaVersion": 6,
+    },
     "plugins": [
         "@sencha/extjs"
     ],

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ __pycache__
 pytests.xml
 nosetests.xml
 coverage.xml
+
+# Compiliation output
+WebApp/static/extjs/
+*.gz

--- a/Core/App.py
+++ b/Core/App.py
@@ -181,7 +181,7 @@ class App(object):
                     keyfile=Conf.HTTPSKey(),
                     cert_reqs=ssl.CERT_OPTIONAL,
                     ca_certs=Conf.generateCAFile(),
-                    ssl_version=ssl.PROTOCOL_TLSv1)
+                    ssl_version=ssl.PROTOCOL_TLSv1_2)
 
       sslprotocol = str(Conf.SSLProrocol())
       aviableProtocols = [i for i in dir(ssl) if i.find('PROTOCOL') == 0]

--- a/WebApp/static/DIRAC/ResourceSummary/classes/OverviewPanel.js
+++ b/WebApp/static/DIRAC/ResourceSummary/classes/OverviewPanel.js
@@ -452,6 +452,12 @@ Ext.define("DIRAC.ResourceSummary.classes.OverviewPanel", {
 
                   var width = me.timeline.getWidth() - 20;
                   document.getElementById(me.id + "-timeline-plot").style.width = "" + width + "px";
+                  if (typeof google === 'undefined') {
+                    Ext.dirac.system_info.msg(
+                      "Error", "Failed to load Google visualization libraries, " +
+                      "some content will be missing. Is googleapis.com blocked?");
+                      return;
+                  }
                   var chart = new google.visualization.AnnotatedTimeLine(document.getElementById(me.id + "-timeline-plot"));
                   var data = new google.visualization.DataTable();
                   data.addColumn('datetime', 'DateTime');

--- a/WebApp/static/DIRAC/TransformationMonitor/classes/TransformationMonitor.js
+++ b/WebApp/static/DIRAC/TransformationMonitor/classes/TransformationMonitor.js
@@ -970,8 +970,8 @@ Ext.define('DIRAC.TransformationMonitor.classes.TransformationMonitor', {
         
         /*
          * var oMenu = new Ext.menu.Menu({ items : [{ text : 'Show value',
-         * handler : Ext.bind(parent.getContainer().showValue, oGrid, [oGrid],
-         * false) }] }); oGrid.menu = oMenu;
+         * handler : parent.getContainer().showValue.bind(oGrid, oGrid)
+         * }] }); oGrid.menu = oMenu;
          */
         parent.getContainer().showInWindow("Files with status " + oStatus + " for production:" + oId, oGrid);
         parent.grid.body.unmask();

--- a/WebApp/static/core/js/core/App.js
+++ b/WebApp/static/core/js/core/App.js
@@ -120,12 +120,7 @@ Ext.define('Ext.dirac.core.App', {
         /*
          * Starting capturing the X, Y coordinates of the mouse cursor
          */
-        // If NS -- that is, !IE -- then set up for mouse capture
-        if (!GLOBAL.IS_IE)
-          document.captureEvents(Event.MOUSEMOVE);
-
-        // Set-up to use getMouseXY function onMouseMove
-        document.onmousemove = me.__getMouseXY;
+        document.addEventListener("mousemove", me.__getMouseXY);
 
         Ext.dirac.system_info = me.CF;
 

--- a/WebApp/static/core/js/core/App.js
+++ b/WebApp/static/core/js/core/App.js
@@ -12,9 +12,6 @@ Ext.define('Ext.dirac.core.App', {
 
       requires : ['Ext.container.Viewport', 'Ext.window.MessageBox', 'Ext.dirac.core.CommonFunctions', 'Ext.dirac.core.StateManagement',
         'Ext.dirac.utils.WelcomeWindow',
-        'Ext.dirac.views.tabs.ContextMenu',
-        'Ext.dirac.views.tabs.SettingsPanel',
-        'Ext.dirac.views.tabs.DesktopSettings',
       ],
 
       /**

--- a/WebApp/static/core/js/core/App.js
+++ b/WebApp/static/core/js/core/App.js
@@ -10,7 +10,12 @@ Ext.define('Ext.dirac.core.App', {
         fileLoader : 'Ext.dirac.utils.DiracFileLoad'
       },
 
-      requires : ['Ext.container.Viewport', 'Ext.window.MessageBox', 'Ext.dirac.core.CommonFunctions', 'Ext.dirac.core.StateManagement'],
+      requires : ['Ext.container.Viewport', 'Ext.window.MessageBox', 'Ext.dirac.core.CommonFunctions', 'Ext.dirac.core.StateManagement',
+        'Ext.dirac.utils.WelcomeWindow',
+        'Ext.dirac.views.tabs.ContextMenu',
+        'Ext.dirac.views.tabs.SettingsPanel',
+        'Ext.dirac.views.tabs.DesktopSettings',
+      ],
 
       /**
        * @property {boolean} isReady

--- a/WebApp/static/core/js/core/Container.js
+++ b/WebApp/static/core/js/core/Container.js
@@ -79,7 +79,7 @@ Ext.define('Ext.dirac.core.Container', {
           for (var i in menu) {
             oMenu.add({
                   'text' : menu[i].text,
-                  handler : Ext.bind(menu[i].handler, oGrid, menu[i].arguments, false)
+                  handler : menu[i].handler.bind(oGrid, ...(menu[i].arguments || []))
                 });
           }
           oGrid.menu = oMenu;

--- a/WebApp/static/core/js/utils/DiracApplicationContextMenu.js
+++ b/WebApp/static/core/js/utils/DiracApplicationContextMenu.js
@@ -62,7 +62,7 @@ Ext.define('Ext.dirac.utils.DiracApplicationContextMenu', {
               } else if ("handler" in oConfig.menu.Visible[i]) {
                 oMenuItem = new Ext.menu.Item({
                       text : oConfig.menu.Visible[i].text,
-                      handler : Ext.bind(oConfig.menu.Visible[i].handler, me.scope, oConfig.menu.Visible[i].arguments, false),
+                      handler : oConfig.menu.Visible[i].handler.bind(me.scope, ...(oConfig.menu.Visible[i].arguments || [])),
                       scope : me.scope
                     });
               } else if ("subMenu" in oConfig.menu.Visible[i]) {
@@ -90,7 +90,7 @@ Ext.define('Ext.dirac.utils.DiracApplicationContextMenu', {
               } else if ("handler" in oConfig.menu.Protected[i]) {
                 oMenuItem = new Ext.menu.Item({
                       text : oConfig.menu.Protected[i].text,
-                      handler : Ext.bind(oConfig.menu.Protected[i].handler, me.scope, oConfig.menu.Protected[i].arguments, false),
+                      handler : oConfig.menu.Protected[i].handler.bind(me.scope, ...(oConfig.menu.Protected[i].arguments || [])),
                       scope : me.scope,
                       disabled : lDisable
                     });
@@ -133,7 +133,7 @@ Ext.define('Ext.dirac.utils.DiracApplicationContextMenu', {
               } else if ("handler" in subMenu.Visible[i]) {
                 var oMenuItem = new Ext.menu.Item({
                       text : subMenu.Visible[i].text,
-                      handler : Ext.bind(subMenu.Visible[i].handler, me.scope, subMenu.Visible[i].arguments, false),
+                      handler : subMenu.Visible[i].handler.bind(me.scope, ...(subMenu.Visible[i].arguments || [])),
                       scope : me.scope
                     });
               } else if ("subMenu" in subMenu.Visible[i]) {
@@ -160,7 +160,7 @@ Ext.define('Ext.dirac.utils.DiracApplicationContextMenu', {
               } else if ("handler" in subMenu.Protected[i]) {
                 var oMenuItem = new Ext.menu.Item({
                       text : subMenu.Protected[i].text,
-                      handler : Ext.bind(subMenu.Protected[i].handler, me.scope, subMenu.Protected[i].arguments, false),
+                      handler : subMenu.Protected[i].handler.bind(me.scope, ...(subMenu.Protected[i].arguments || [])),
                       scope : me.scope,
                       disabled : lDisable
                     });

--- a/WebApp/static/core/js/utils/DiracPagingToolbar.js
+++ b/WebApp/static/core/js/utils/DiracPagingToolbar.js
@@ -131,7 +131,7 @@ Ext.define('Ext.dirac.utils.DiracPagingToolbar', {
               } else {
                 me.pagingToolbarButtons[nbOfButtons] = Ext.create('Ext.Button', {
                       text : config.toolButtons.Visible[i].text,
-                      handler : Ext.bind(config.toolButtons.Visible[i].handler, config.scope, config.toolButtons.Visible[i].arguments, false)
+                      handler : config.toolButtons.Visible[i].handler.bind(config.scope, ...(config.toolButtons.Visible[i].arguments || []))
                     });
                 if ("properties" in config.toolButtons.Visible[i]) {
                   Ext.apply(me.pagingToolbarButtons[nbOfButtons], config.toolButtons.Visible[i].properties);
@@ -148,7 +148,7 @@ Ext.define('Ext.dirac.utils.DiracPagingToolbar', {
                 } else {
                   me.pagingToolbarButtons[nbOfButtons] = Ext.create('Ext.Button', {
                         text : config.toolButtons.Protected[i].text,
-                        handler : Ext.bind(config.toolButtons.Protected[i].handler, config.scope, config.toolButtons.Protected[i].arguments, false)
+                        handler : config.toolButtons.Protected[i].handler.bind(config.scope, ...(config.toolButtons.Protected[i].arguments || []))
                       });
                   if ("properties" in config.toolButtons.Protected[i]) {
                     Ext.apply(me.pagingToolbarButtons[nbOfButtons], config.toolButtons.Protected[i].properties);

--- a/WebApp/static/core/js/utils/Printer.js
+++ b/WebApp/static/core/js/utils/Printer.js
@@ -251,7 +251,7 @@ Ext.define("Ext.dirac.utils.Printer", {
          */
         bodyTpl: [
             '<tpl for=".">',
-                '<td>\{{[Ext.String.createVarName(values.text)]}\}</td>',
+                '<td>{{[Ext.String.createVarName(values.text)]}}</td>',
             '</tpl>'
         ]
     }

--- a/WebApp/static/core/js/utils/css/DiracBoxSelect.css
+++ b/WebApp/static/core/js/utils/css/DiracBoxSelect.css
@@ -24,7 +24,7 @@ ul.x-boxselect-list.x-boxselect-singleselect {
 	display: inline-block;
 	position: relative;
 	*display:inline; /* IE7 */
-	zoom:1; /* IE */
+	transform: scale(1); /* IE */
 }
 .x-boxselect-stacked .x-boxselect-item {
 	display: block;

--- a/WebApp/static/core/js/utils/css/PlotView.css
+++ b/WebApp/static/core/js/utils/css/PlotView.css
@@ -147,7 +147,7 @@
     opacity: .5;
     -moz-opacity: .5;
     filter:alpha(opacity=50);
-    zoom:1;
+    transform: scale(1);
     background-color:#c3daf9;
     border-color:#3399bb;
 }.ext-strict .ext-ie .x-tree .x-panel-bwrap{

--- a/WebApp/static/core/js/views/desktop/StartMenu.js
+++ b/WebApp/static/core/js/views/desktop/StartMenu.js
@@ -156,7 +156,7 @@ Ext.define('Ext.dirac.views.desktop.StartMenu', {
                 activate : function(oMenuItem, eOpts) {
 
                 },
-                click : Ext.bind(GLOBAL.APP.MAIN_VIEW.createWindow, GLOBAL.APP.MAIN_VIEW, [item[0], item[2], null]),
+                click : GLOBAL.APP.MAIN_VIEW.createWindow.bind(GLOBAL.APP.MAIN_VIEW, item[0], item[2], null),
                 focus : function(cmp, e, eOpts) {
 
                   if (!GLOBAL.STATE_MANAGEMENT_ENABLED)
@@ -239,9 +239,13 @@ Ext.define('Ext.dirac.views.desktop.StartMenu', {
 
                   oNewItem = Ext.create('Ext.menu.Item', {
                         text : stateName,
-                        handler : Ext.bind(GLOBAL.APP.MAIN_VIEW.createWindow, GLOBAL.APP.MAIN_VIEW, ["app", oThisMenu.appClassName, {
-                                  stateToLoad : stateName
-                                }], false),
+                        handler : GLOBAL.APP.MAIN_VIEW.createWindow.bind(
+                          GLOBAL.APP.MAIN_VIEW,
+                          "app",
+                          oThisMenu.appClassName, {
+                            stateToLoad : stateName
+                          }
+                        ),
                         scope : me,
                         iconCls : "dirac-icon-state",
                         stateType : stateType,
@@ -288,7 +292,7 @@ Ext.define('Ext.dirac.views.desktop.StartMenu', {
                   oNewItem = Ext.create('Ext.menu.Item', {
                         text : stateName,
                         minWidth : 200,
-                        handler : Ext.bind(GLOBAL.APP.MAIN_VIEW.loadSharedStateByName, GLOBAL.APP.MAIN_VIEW, [oThisMenu.appClassName, stateName], false),
+                        handler : GLOBAL.APP.MAIN_VIEW.loadSharedStateByName.bind(GLOBAL.APP.MAIN_VIEW, oThisMenu.appClassName, stateName),
                         scope : me,
                         iconCls : "dirac-icon-link",
                         stateType : stateType
@@ -357,9 +361,13 @@ Ext.define('Ext.dirac.views.desktop.StartMenu', {
                   var newItem = Ext.create('Ext.menu.Item', {
                         text : stateName,
                         minWidth : 200,
-                        handler : Ext.bind(GLOBAL.APP.MAIN_VIEW.createWindow, GLOBAL.APP.MAIN_VIEW, ["app", oThisMenu.appClassName, {
-                                  stateToLoad : stateName
-                                }], false),
+                        handler : GLOBAL.APP.MAIN_VIEW.createWindow.bind(
+                          GLOBAL.APP.MAIN_VIEW,
+                          "app",
+                          oThisMenu.appClassName, {
+                            stateToLoad : stateName
+                          }
+                        ),
                         scope : me,
                         iconCls : "dirac-icon-state",
                         stateType : "application",
@@ -415,7 +423,7 @@ Ext.define('Ext.dirac.views.desktop.StartMenu', {
 
                   var newItem = Ext.create('Ext.menu.Item', {
                         text : stateName,
-                        handler : Ext.bind(GLOBAL.APP.MAIN_VIEW.loadSharedStateByName, GLOBAL.APP.MAIN_VIEW, [oThisMenu.appClassName, stateName], false),
+                        handler : GLOBAL.APP.MAIN_VIEW.loadSharedStateByName.bind(GLOBAL.APP.MAIN_VIEW, oThisMenu.appClassName, stateName),
                         scope : me,
                         iconCls : "dirac-icon-link",
                         minWidth : 200,
@@ -433,9 +441,7 @@ Ext.define('Ext.dirac.views.desktop.StartMenu', {
 
             return {
               text : item[1],
-              handler : Ext.bind(GLOBAL.APP.MAIN_VIEW.createWindow, GLOBAL.APP.MAIN_VIEW, [item[0], item[2], {
-                        title : item[1]
-                      }]),
+              handler : GLOBAL.APP.MAIN_VIEW.createWindow.bind(GLOBAL.APP.MAIN_VIEW, item[0], item[2], {title : item[1]}),
               minWidth : 200,
               iconCls : "system_web_window"
             };

--- a/WebApp/static/core/js/views/desktop/Window.js
+++ b/WebApp/static/core/js/views/desktop/Window.js
@@ -672,12 +672,12 @@ Ext.define('Ext.dirac.views.desktop.Window', {
                     }, {
                       text : "Save",
                       iconCls : "dirac-icon-save",
-                      handler : Ext.bind(me.desktop.SM.oprSaveAppState, me.desktop.SM, ["application", me.loadedObject.self.getName(), me.loadedObject, funcAfterSave], false),
+                      handler : me.desktop.SM.oprSaveAppState.bind(me.desktop.SM, "application", me.loadedObject.self.getName(), me.loadedObject, funcAfterSave),
                       scope : me
                     }, {
                       text : "Save As ...",
                       iconCls : "dirac-icon-save",
-                      handler : Ext.bind(me.desktop.SM.formSaveState, me.desktop.SM, ["application", me.loadedObject.self.getName(), me.loadedObject, funcAfterSave], false),
+                      handler : me.desktop.SM.formSaveState.bind(me.desktop.SM, "application", me.loadedObject.self.getName(), me.loadedObject, funcAfterSave),
                       scope : me
                     }, {
                       text : "Refresh states",
@@ -687,7 +687,7 @@ Ext.define('Ext.dirac.views.desktop.Window', {
                     }, {
                       text : "Manage states ...",
                       iconCls : "toolbar-other-manage",
-                      handler : Ext.bind(me.desktop.SM.formManageStates, me.desktop.SM, [me.loadedObject.self.getName(), funcAfterRemove], false),
+                      handler : me.desktop.SM.formManageStates.bind(me.desktop.SM, me.loadedObject.self.getName(), funcAfterRemove),
                       scope : me
                     }]
               });
@@ -758,7 +758,7 @@ Ext.define('Ext.dirac.views.desktop.Window', {
 
           var newItem = Ext.create('Ext.menu.Item', {
                 text : stateName,
-                handler : Ext.bind(me.oprLoadAppStateFromCache, me, [stateName], false),
+                handler : me.oprLoadAppStateFromCache.bind(me, stateName),
                 scope : me,
                 iconCls : "dirac-icon-state",
                 stateType : stateType,
@@ -810,7 +810,7 @@ Ext.define('Ext.dirac.views.desktop.Window', {
 
           var newItem = Ext.create('Ext.menu.Item', {
                 text : stateName,
-                handler : Ext.bind(me.desktop.loadSharedStateByName, me.desktop, [me.appClassName, stateName], false),
+                handler : me.desktop.loadSharedStateByName.bind(me.desktop, me.appClassName, stateName),
                 scope : me,
                 iconCls : "dirac-icon-link",
                 stateType : stateType
@@ -898,7 +898,7 @@ Ext.define('Ext.dirac.views.desktop.Window', {
 
           var oNewItem = Ext.create('Ext.menu.Item', {
                 text : stateName,
-                handler : Ext.bind(me.oprLoadAppStateFromCache, me, [stateName], false),
+                handler : me.oprLoadAppStateFromCache.bind(me, stateName),
                 scope : me,
                 iconCls : "dirac-icon-state",
                 stateType : "application",
@@ -948,7 +948,7 @@ Ext.define('Ext.dirac.views.desktop.Window', {
 
           var oNewItem = Ext.create('Ext.menu.Item', {
                 text : stateName,
-                handler : Ext.bind(me.desktop.loadSharedStateByName, me.desktop, [me.appClassName, stateName], false),
+                handler : me.desktop.loadSharedStateByName.bind(me.desktop, me.appClassName, stateName),
                 scope : me,
                 iconCls : "dirac-icon-link",
                 stateType : "reference"

--- a/WebApp/static/core/js/views/desktop/Window.js
+++ b/WebApp/static/core/js/views/desktop/Window.js
@@ -89,7 +89,8 @@ Ext.define('Ext.dirac.views.desktop.Window', {
           minimized : false
         };
 
-        me.loadMask = new Ext.LoadMask(me, {
+        me.loadMask = new Ext.LoadMask({
+              target : me,
               msg : "Loading ..."
             });
 

--- a/WebApp/static/core/js/views/tabs/Main.js
+++ b/WebApp/static/core/js/views/tabs/Main.js
@@ -75,7 +75,8 @@ Ext.define('Ext.dirac.views.tabs.Main', {
         }// hack
         // ///////////////////////////END///////////////////////////
         me.rightContainer = Ext.create('Ext.dirac.views.tabs.RightContainer');
-        me.loadRightContainer = new Ext.LoadMask(me.rightContainer, {
+        me.loadRightContainer = new Ext.LoadMask({
+              target: me.rightContainer,
               msg : "Loading desktops and applications...",
               iCode : 1
             });
@@ -85,7 +86,8 @@ Ext.define('Ext.dirac.views.tabs.Main', {
         me.leftConatiner = Ext.create('Ext.dirac.views.tabs.LeftContainer', {
               menu : menu
             });
-        me.loadleftContainer = new Ext.LoadMask(me.leftConatiner, {
+        me.loadleftContainer = new Ext.LoadMask({
+              target : me.leftConatiner,
               msg : "Loading menu ...",
               iCode : 1
             });

--- a/WebApp/static/core/js/views/tabs/Panel.js
+++ b/WebApp/static/core/js/views/tabs/Panel.js
@@ -117,7 +117,8 @@ Ext.define('Ext.dirac.views.tabs.Panel', {
       initComponent : function() {
         var me = this;
 
-        me.loadMask = new Ext.LoadMask(me, {
+        me.loadMask = new Ext.LoadMask({
+              target : me,
               msg : "Loading ..."
             });
 

--- a/WebApp/static/core/js/views/tabs/SelPanel.js
+++ b/WebApp/static/core/js/views/tabs/SelPanel.js
@@ -18,7 +18,8 @@ Ext.define('Ext.dirac.views.tabs.SelPanel', {
       split : true,
       initComponent : function() {
         var me = this;
-        me.loadMask = new Ext.LoadMask(me, {
+        me.loadMask = new Ext.LoadMask({
+              target : me,
               msg : "Loading menu..."
             });
         Ext.apply(me, {
@@ -55,7 +56,7 @@ Ext.define('Ext.dirac.views.tabs.SelPanel', {
                     return;
                   }
                   /*
-                   * this.loadMask = new Ext.LoadMask(node, { msg : "Loading
+                   * this.loadMask = new Ext.LoadMask({ target : node, msg : "Loading
                    * ..." });
                    */
                   var activeDesktop = GLOBAL.APP.MAIN_VIEW.getActiveDesktop(); // do

--- a/WebApp/static/core/js/views/tabs/SelPanel.js
+++ b/WebApp/static/core/js/views/tabs/SelPanel.js
@@ -3,7 +3,7 @@
  */
 Ext.define('Ext.dirac.views.tabs.SelPanel', {
       extend : 'Ext.panel.Panel',
-      requies : ['Ext.dirac.views.tabs.ContextMenu', 'Ext.dirac.views.tabs.TreeMenuModel', 'Ext.tree.plugin.TreeViewDragDrop', 'Ext.dirac.views.tabs.SettingsPanel', 'Ext.LoadMask', 'Ext.dirac.views.tabs.StateManagerMenu'],
+      requires : ['Ext.dirac.views.tabs.ContextMenu', 'Ext.dirac.views.tabs.TreeMenuModel', 'Ext.tree.plugin.TreeViewDragDrop', 'Ext.dirac.views.tabs.SettingsPanel', 'Ext.LoadMask', 'Ext.dirac.views.tabs.StateManagerMenu'],
       xtype : 'menuselpanel',
       alias : 'widget.selPanel',
       /**

--- a/WebApp/static/core/js/views/tabs/SettingsPanel.js
+++ b/WebApp/static/core/js/views/tabs/SettingsPanel.js
@@ -3,7 +3,7 @@
  */
 Ext.define('Ext.dirac.views.tabs.SettingsPanel', {
       extend : 'Ext.panel.Panel',
-      required : ['Ext.form.Panel', 'Ext.dirac.views.tabs.DesktopSettings'],
+      requires : ['Ext.form.Panel', 'Ext.dirac.views.tabs.DesktopSettings'],
       title : 'Settings',
       frame : false,
       width : 200,

--- a/WebApp/static/core/js/views/tabs/TabPanel.js
+++ b/WebApp/static/core/js/views/tabs/TabPanel.js
@@ -44,7 +44,7 @@ Ext.define('Ext.dirac.views.tabs.TabPanel', {
        
         me.callParent(arguments);
         /*
-         * me.loadMask = new Ext.LoadMask(me, { msg : "Loading ..." });
+         * me.loadMask = new Ext.LoadMask({ target : me, msg : "Loading ..." });
          */
       },
       loadState : function(data) {

--- a/WebApp/static/core/js/views/tabs/TabPanel.js
+++ b/WebApp/static/core/js/views/tabs/TabPanel.js
@@ -20,7 +20,7 @@ Ext.define('Ext.dirac.views.tabs.TabPanel', {
       view : 'tabView',
       renderTo : Ext.getBody(),
       defaults: {
-        bodyPadding: 10,
+        bodyPadding: 0,
         scrollable: true
     },
       bodyStyle : {

--- a/WebApp/template/root.tpl
+++ b/WebApp/template/root.tpl
@@ -47,8 +47,10 @@
     
     <!-- </x-bootstrap> -->
     <script type="text/javascript">
-      google.load("visualization", "1", {packages:["corechart","annotatedtimeline"]});
-      
+      if (typeof google !== 'undefined') { // google is blocked in some locations
+        google.load("visualization", "1", {packages:["corechart","annotatedtimeline"]});
+      }
+
       //Wrap console.log if it does not exist
       if (typeof console == "undefined") {
         window.console = {


### PR DESCRIPTION
This:

* removes a bunch of errors and warnings which appear in the developer console when browsing the web app.
* changes the default TLS version in tornado. This is badly needed both for security if not using nginx and as browsers are removing support: https://www.chromestatus.com/feature/5759116003770368
* allows the webapp to be mostly functional if google.com is blocked (fixes #387)

I've also modified the eslint configuration to set the version to ES6. This is needed for 48d7a6d35233556b99cccd7b1a26dd6d40b7a4bc and I think it's reasonable as ES6 is from 2015 and nobody should be using the web app in a browser that is that outdated. If people disagree I'll rebase that commit out of this PR.

I've been using a local copy of the webapp for a couple of weeks against LHCbDIRAC without any issues so these changes should be fairly well tested.

BEGINRELEASENOTES

FIX: WebApp hangs indefinitely if google.com is blocked (#387)
CHANGE: Default to TLS 1.2
FIX: Fix minor deprecation warnings in extjs and modern browsers

ENDRELEASENOTES
