### PR TITLE
[v4r0] Fixing typo: SSLProrocol, SSLProtcol, with backward compatibility

### DIFF
--- a/Core/App.py
+++ b/Core/App.py
@@ -183,7 +183,7 @@ class App(object):
                     ca_certs=Conf.generateCAFile(),
                     ssl_version=ssl.PROTOCOL_TLSv1)
 
-      sslprotocol = str(Conf.SSLProrocol())
+      sslprotocol = str(Conf.SSLProtocol())
       aviableProtocols = [i for i in dir(ssl) if i.find('PROTOCOL') == 0]
       if sslprotocol and sslprotocol != "":
         if (sslprotocol in aviableProtocols):

--- a/Lib/Conf.py
+++ b/Lib/Conf.py
@@ -166,6 +166,10 @@ def SSLProrocol():
   return getCSValue("SSLProtcol", "")
 
 
+def SSLProtocol():
+  return getCSValue("SSLProtocol", getCSValue("SSLProtcol", ""))
+
+
 def getStaticDirs():
   return getCSValue("StaticDirs", [])
 


### PR DESCRIPTION

BEGINRELEASENOTES
FIX: Fixing typo: SSLProrocol in the codes and SSLProtcol in the CS parameter. SSLProtocol should be used with this fix, but the CS parameter SSLProtcol, when it exists, is still effective unless SSLProtocol is set
ENDRELEASENOTES
