### PR TITLE
[v4r0] Fix attribute error for X509CRL.loadChainFromFile in Lib/Conf.py

### DIFF
--- a/Lib/Conf.py
+++ b/Lib/Conf.py
@@ -141,7 +141,7 @@ def generateRevokedCertsFile():
     for caFile in os.listdir(caDir):
       caFile = os.path.join(caDir, caFile)
       chain = X509CRL.X509CRL()
-      result = chain.loadChainFromFile(caFile)
+      result = chain.loadCRLFromFile(caFile)
       if not result['OK']:
         continue
       fd.write(chain.dumpAllToString()['Value'])


### PR DESCRIPTION
Fixes a bad refactor from #397 

BEGINRELEASENOTES

FIX: Attribute error for X509CRL.loadChainFromFile in Lib/Conf.py

ENDRELEASENOTES
