### PR TITLE
[v4r0] DN should be a string when passed to isTrustedHost

### DIFF
--- a/Lib/WebHandler.py
+++ b/Lib/WebHandler.py
@@ -325,7 +325,7 @@ class WebHandler(tornado.web.RequestHandler):
       else:
         self.__credDict['validDN'] = False
         self.log.info("AUTH OK: %s by visitor" % (handlerRoute))
-    elif self.isTrustedHost(self.__credDict.get('DN')):
+    elif self.isTrustedHost(self.__credDict.get('DN', '')):
       self.log.info("Request is coming from Trusted host")
       return True
     else:


### PR DESCRIPTION
BEGINRELEASENOTES

FIX: DN should be a string when passed to isTrustedHost

ENDRELEASENOTES

Fixes:
```
Traceback (most recent call last):
  File "/opt/dirac/pro/diracos/usr/lib64/python2.7/site-packages/tornado/http1connection.py", line 238, in _read_message
    delegate.finish()
  File "/opt/dirac/pro/diracos/usr/lib64/python2.7/site-packages/tornado/httpserver.py", line 319, in finish
    self.delegate.finish()
  File "/opt/dirac/pro/diracos/usr/lib64/python2.7/site-packages/tornado/routing.py", line 256, in finish
    self.delegate.finish()
  File "/opt/dirac/pro/diracos/usr/lib64/python2.7/site-packages/tornado/web.py", line 2195, in finish
    self.execute()
  File "/opt/dirac/pro/diracos/usr/lib64/python2.7/site-packages/tornado/web.py", line 2215, in execute
    **self.handler_kwargs)
  File "/opt/dirac/pro/WebAppDIRAC/Lib/WebHandler.py", line 155, in __init__
    self._pathResult = self.__checkPath(*match.groups())
  File "/opt/dirac/pro/WebAppDIRAC/Lib/WebHandler.py", line 361, in __checkPath
    if not self.__auth(handlerRoute, group, methodName):
  File "/opt/dirac/pro/WebAppDIRAC/Lib/WebHandler.py", line 328, in __auth
    elif self.isTrustedHost(self.__credDict.get('DN')):
  File "/opt/dirac/pro/WebAppDIRAC/Lib/WebHandler.py", line 341, in isTrustedHost
    retVal = Registry.getHostnameForDN(dn)
  File "/opt/dirac/pro/DIRAC/ConfigurationSystem/Client/Helpers/Registry.py", line 133, in getHostnameForDN
    dn = dn.strip()
```