### PR TITLE
[v4r0] Fix PilotMonitor showJobs function

### DIFF
--- a/WebApp/handler/JobMonitorHandler.py
+++ b/WebApp/handler/JobMonitorHandler.py
@@ -232,6 +232,11 @@ class JobMonitorHandler(WebHandler):
       if jobids:
         req['JobID'] = jobids
 
+    if "PilotJobReference" in self.request.arguments:
+      pilotids = list(json.loads(self.request.arguments['PilotJobReference'][-1]))
+      if pilotids:
+        req['PilotJobReference'] = pilotids
+
     if "jobGroup" in self.request.arguments:
       prodids = list(json.loads(self.request.arguments['jobGroup'][-1]))
       if prodids:

--- a/WebApp/static/DIRAC/JobMonitor/classes/JobMonitor.js
+++ b/WebApp/static/DIRAC/JobMonitor/classes/JobMonitor.js
@@ -251,6 +251,10 @@ Ext.define('DIRAC.JobMonitor.classes.JobMonitor', {
           'JobID' : {
             name : "JobID(s)",
             type : "number"
+          },
+          PilotJobReference: {
+            name: "Pilot Job Reference(s)",
+            type: "originalText"
           }
         };
 

--- a/WebApp/static/DIRAC/PilotMonitor/classes/PilotMonitor.js
+++ b/WebApp/static/DIRAC/PilotMonitor/classes/PilotMonitor.js
@@ -276,50 +276,25 @@ Ext.define('DIRAC.PilotMonitor.classes.PilotMonitor', {
             });
 
         var showJobshandler = function() {
-          var oId = GLOBAL.APP.CF.getFieldValueFromSelectedRow(me.grid, "CurrentJobID");
-          if (oId != '-') {
-            var oSetupData = {};
-            if (GLOBAL.VIEW_ID == "desktop") { // we needs these
-              // information only
-              // for the desktop
-              // layout.
+          var oId = GLOBAL.APP.CF.getFieldValueFromSelectedRow(me.grid, "PilotJobReference");
 
-              var oDimensions = GLOBAL.APP.MAIN_VIEW.getViewMainDimensions();
-              oSetupData.x = 0;
-              oSetupData.y = 0;
-              oSetupData.width = oDimensions[0];
-              oSetupData.height = oDimensions[1];
-              oSetupData.currentState = "";
-
-              oSetupData.desktopStickMode = 0;
-              oSetupData.hiddenHeader = 1;
-              oSetupData.i_x = 0;
-              oSetupData.i_y = 0;
-              oSetupData.ic_x = 0;
-              oSetupData.ic_y = 0;
-
-            }
-
-            oSetupData.data = {
-
-              leftMenu : {
-                JobID : oId
-              }
-            };
-
-            GLOBAL.APP.MAIN_VIEW.createNewModuleContainer({
-                  objectType : "app",
-                  moduleName : me.applicationsToOpen["JobMonitor"],
-                  setupData : oSetupData
-                });
-          }
+          var setupdata = {};
+          setupdata.data = {};
+          setupdata.currentState = oId;
+          setupdata.data.leftMenu = {};
+          setupdata.data.leftMenu.PilotJobReference = oId;
+          GLOBAL.APP.MAIN_VIEW.createNewModuleContainer({
+            objectType: "app",
+            moduleName: me.applicationsToOpen["JobMonitor"],
+            setupData: setupdata
+          });
         };
         var menuitems = {
           'Visible' : [{
                 "text" : "Show Jobs",
                 "handler" : showJobshandler,
                 "properties" : {
-                  tooltip : 'Click to show the jobs which belong to the selected transformation(s).'
+                  tooltip: "Click to show the jobs bound to the selected pilot job reference(s)."
                 }
               }, {
                 "text" : "-"


### PR DESCRIPTION
The `PilotMonitor/showJobs` feature opens a `JobMonitor` window to see the `CurrentJobID` only.
DIRAC Pilot-Jobs are able to handle multiple jobs: on HPCs, Pilot-Jobs can handle tens of jobs at the same time.
It would be easier to debug issues in the Pilot-Jobs if we would have access to all the jobs bound to a specific Pilot-Job instead of the current one.

This PR adds a new selector textfield in the JobMonitor to search jobs by Pilot-Job reference.
Change made in DIRAC are available here: https://github.com/DIRACGrid/DIRAC/pull/4772

BEGINRELEASENOTES
FIX: PilotMonitor showJobs feature now provide all the jobs bound to a pilot-job reference
ENDRELEASENOTES
