### PR TITLE
[v4r0] Disable bufferedRenderer in RegistryManager to allow better searching 

### DIFF
--- a/WebApp/static/DIRAC/RegistryManager/classes/RegistryManager.js
+++ b/WebApp/static/DIRAC/RegistryManager/classes/RegistryManager.js
@@ -664,6 +664,7 @@ Ext.define('DIRAC.RegistryManager.classes.RegistryManager',
 						enableTextSelection : true
 					},
 					columns : me.gridColumns["users"],
+					bufferedRenderer: false,
 					listeners : {
 
 						cellclick : function(oTable, td, cellIndex, record, tr, rowIndex, e, eOpts) {


### PR DESCRIPTION
As reported on the forum. I agree it's annoying and I'm not convinced there is any performance benefit for most of DIRAC's pages.

BEGINRELEASENOTES

FIX:  Disable bufferedRenderer in RegistryManager to allow better searching 

ENDRELEASENOTES

@TaykYoku Could you take a look for if there are other places that would benefit from this? (such as the Configuration Manager, though maybe that's too big when fully expanded?)
