### PR TITLE
[v4r2] move web.cfg to main CS

### DIFF
--- a/WebApp/handler/AuthenticationHandler.py
+++ b/WebApp/handler/AuthenticationHandler.py
@@ -24,7 +24,7 @@ class AuthenticationHandler(WebHandler):
         (loadValue[0], loadValue[1]), body='Type auth: %s, details: %s' %
         (typeAuth, loadValue))
 
-  # Get information from web.cfg about auth types
+  # Get information from CS about auth types
   @asyncGen
   def web_getAuthCFG(self):
     typeAuth = str(self.request.arguments["typeauth"][0])

--- a/WebApp/static/DIRAC/ExampleApp/classes/ExampleApp.js
+++ b/WebApp/static/DIRAC/ExampleApp/classes/ExampleApp.js
@@ -2,7 +2,7 @@
  * This is a simple example which describes how to use predefined widgets and how to create a new application. We used the following steps to create the first application:
  *
  *    - We called our first application ExampleApp.
- *    - We added the following line to the web.cfg: ExampleApp = DIRAC.ExampleApp
+ *    - We added the following line to the CS in the WebApp section: ExampleApp = DIRAC.ExampleApp
  *    - We created ExampleApp directory under DIRAC. We created two directories under ExampleApp called: classes and css.
  *    - classes directory contains the ExampleApp.js while the css directory contains the ExampleApp.css
  *    - We implemented the ExampleApp.js class

--- a/WebApp/static/DIRAC/FileCatalog/classes/FileCatalog.js
+++ b/WebApp/static/DIRAC/FileCatalog/classes/FileCatalog.js
@@ -489,7 +489,7 @@ Ext.define("DIRAC.FileCatalog.classes.FileCatalog", {
     });
 
     /*
-     * Read application settings from web.cfg to build panel
+     * Read application settings from CS(WebApp section) to build panel
      */
     var pagingToolbarItems = [];
     if (GLOBAL.APP.configData.configuration.hasOwnProperty("FileCatalog") && GLOBAL.APP.configData.configuration.FileCatalog.pagingToolbar) {

--- a/WebApp/web.cfg
+++ b/WebApp/web.cfg
@@ -1,3 +1,5 @@
+# Example of the WebApp section configuration
+
 WebApp
 {
   #If you want to use nginx, please uncomment the following two lines: 


### PR DESCRIPTION
BEGINRELEASENOTES
Use web.cfg as example and /WebApp section in dirac.cfg to configure Web portal. Directly depends on [#4829](https://github.com/DIRACGrid/DIRAC/pull/4829).



CHANGE: don't read web.cfg

ENDRELEASENOTES
