### PR TITLE
Continue loading even if one handler is broken

### DIFF
--- a/Core/HandlerMgr.py
+++ b/Core/HandlerMgr.py
@@ -58,7 +58,7 @@ class HandlerMgr(object):
     """
     ol = ObjectLoader()
     origin = "WebApp.handler"
-    result = ol.getObjects(origin, parentClass=WebHandler, recurse=True)
+    result = ol.getObjects(origin, parentClass=WebHandler, recurse=True, continueOnError=True)
     if not result['OK']:
       return result
     self.__handlers = result['Value']


### PR DESCRIPTION
Needs https://github.com/DIRACGrid/DIRAC/pull/4957
Without this, a single broken module is enough to break the whole portal.

BEGINRELEASENOTES
CHANGE: Do not crash at load time because of one buggy handler

ENDRELEASENOTES
