### PR TITLE
[v4r0] add columns to SiteSummary overview tables

### DIFF
--- a/WebApp/handler/SiteSummaryHandler.py
+++ b/WebApp/handler/SiteSummaryHandler.py
@@ -158,7 +158,7 @@ class SiteSummaryHandler(ResourceSummaryHandler):
                                          None)
 
       for sestatus in sestatuses['Value']:
-        storageElementsStatus.append([sestatus[0], sestatus[2], sestatus[6]])
+        storageElementsStatus.append([sestatus[0], sestatus[1], sestatus[2], sestatus[6]])
 
     self.finish({'success': 'true', 'result': storageElementsStatus, 'total': len(storageElementsStatus)})
 
@@ -187,7 +187,7 @@ class SiteSummaryHandler(ResourceSummaryHandler):
       gLogger.info('cestatus = ' + str(cestatuses))
 
       for cestatus in cestatuses['Value']:
-        computing_elements_status.append([cestatus[0], cestatus[2], cestatus[6]])
+        computing_elements_status.append([cestatus[0], cestatus[1], cestatus[2], cestatus[6]])
 
     self.finish({'success': 'true', 'result': computing_elements_status, 'total': len(computing_elements_status)})
 

--- a/WebApp/static/DIRAC/SiteSummary/classes/OverviewPanel.js
+++ b/WebApp/static/DIRAC/SiteSummary/classes/OverviewPanel.js
@@ -128,7 +128,7 @@ Ext.define("DIRAC.SiteSummary.classes.OverviewPanel", {
             });
 
         var ceStore = new Ext.data.ArrayStore({
-              fields : ["Name", "Status", "Type"],
+              fields : ["Name", "StatusType", "Status", "Type"],
               data : []
             });
 
@@ -197,6 +197,16 @@ Ext.define("DIRAC.SiteSummary.classes.OverviewPanel", {
                     flex : 1,
                     sortable : false,
                     dataIndex : 'Type'
+                  }, {
+                    text : 'StatusType',
+                    flex : 1,
+                    sortable : false,
+                    dataIndex : 'StatusType'
+                  }, {
+                    text : 'Status',
+                    flex : 1,
+                    sortable : false,
+                    dataIndex : 'Status'
                   }],
               width : '100%',
               height : '50%',
@@ -216,7 +226,7 @@ Ext.define("DIRAC.SiteSummary.classes.OverviewPanel", {
             });
 
         var stotageStore = new Ext.data.ArrayStore({
-              fields : ["Name", "Status", "Type"],
+              fields : ["Name", "StatusType", "Status", "Type"],
               data : []
             });
 
@@ -270,6 +280,16 @@ Ext.define("DIRAC.SiteSummary.classes.OverviewPanel", {
                     flex : 1,
                     sortable : false,
                     dataIndex : 'Type'
+                  }, {
+                    text : 'StatusType',
+                    flex : 1,
+                    sortable : false,
+                    dataIndex : 'StatusType'
+                  }, {
+                    text : 'Status',
+                    flex : 1,
+                    sortable : false,
+                    dataIndex : 'Status'
                   }],
               width : '100%',
               height : '50%',


### PR DESCRIPTION

BEGINRELEASENOTES
Addressing the issues discussed in the #428.

NEW: Add columns to SiteSummary overview tables. 

ENDRELEASENOTES
