### PR TITLE
[v4r2] modify replaceImage

### DIFF
--- a/WebApp/static/core/js/utils/PlotView.js
+++ b/WebApp/static/core/js/utils/PlotView.js
@@ -438,12 +438,7 @@ Ext.define("Ext.dirac.utils.PlotView", {
 
           if (response["success"]) {
             var src = GLOBAL.BASE_URL + requestHandler + "/getPlotImg?file=" + response["data"];
-
-            var params = {
-              src: src,
-              params: oParams
-            };
-            me.rightPanel.replaceImage(image, params);
+            me.rightPanel.replaceImage(image, src, oParams);
           } else {
             GLOBAL.APP.CF.alert(response["errors"], "error");
           }

--- a/WebApp/static/core/js/utils/Presenter.js
+++ b/WebApp/static/core/js/utils/Presenter.js
@@ -385,11 +385,15 @@ Ext.define("Ext.dirac.utils.Presenter", {
     return me.lastClickedImage;
   },
   // When you apply new input data for example, need to update image
-  replaceImage: function(oldImage, newImage) {
+  replaceImage: function(image, src, plotParams) {
     var me = this;
-    var img = me.getComponent(oldImage.id);
-    img.plotParams = newImage["params"];
-    img.setSrc(newImage["src"]);
+    if (typeof src === 'object') {
+      plotParams = src.params;
+      src = src.src;
+    }
+    var img = me.getImage(image.id);
+    plotParams && (img.plotParams = plotParams);
+    src != img.src ? img.setSrc(src) : img.updateSrc(src);
   },
   setColumnWidth: function(column) {
     var me = this;
@@ -446,9 +450,8 @@ Ext.define("Ext.dirac.utils.Presenter", {
           params: value.plotParams,
           success: function(responseImg) {
             responseImg = Ext.JSON.decode(responseImg.responseText);
-
             if (responseImg["success"]) {
-              value.updateSrc(GLOBAL.BASE_URL + me.scope.handlers[value.reportType] + "/getPlotImg?file=" + responseImg["data"]);
+              me.replaceImage(value, GLOBAL.BASE_URL + me.scope.handlers[value.reportType] + "/getPlotImg?file=" + responseImg["data"]);
             }
           },
           failure: function(response, opt) {
@@ -467,6 +470,7 @@ Ext.define("Ext.dirac.utils.Presenter", {
 
         me.items.each(function(value, index) {
           value.setLoading("Refreshing image...");
+
           Ext.Ajax.request({
             url: GLOBAL.BASE_URL + me.scope.handlers[value.reportType] + "/generatePlot",
             timeout: me.timeout,
@@ -474,7 +478,7 @@ Ext.define("Ext.dirac.utils.Presenter", {
             success: function(responseImg) {
               responseImg = Ext.JSON.decode(responseImg.responseText);
               if (responseImg["success"]) {
-                value.updateSrc(GLOBAL.BASE_URL + me.scope.handlers[value.reportType] + "/getPlotImg?file=" + responseImg["data"]);
+                me.replaceImage(value, GLOBAL.BASE_URL + me.scope.handlers[value.reportType] + "/getPlotImg?file=" + responseImg["data"]);
               }
             },
             failure: function(response, opt) {


### PR DESCRIPTION
BEGINRELEASENOTES
`setSrc` and `updateSrc` methods have slightly different behaviours, but the purpose is to update the DOM / JS image object. Therefore, not to be confused, implement this choice in `replaceImage` method.

CHANGE: Use universal replaceImage instead setSrc or updateSrc

ENDRELEASENOTES
