### PR TITLE
[integration] Remove unused dynamic discovery of ExtJS version

### DIFF
--- a/src/WebAppDIRAC/Lib/Conf.py
+++ b/src/WebAppDIRAC/Lib/Conf.py
@@ -265,6 +265,7 @@ def SSLProtocol():
   """
   return getCSValue("SSLProtocol", getCSValue("SSLProtcol", ""))
 
+
 def getDefaultStaticDirs():
   """ Get default static directories
 

--- a/src/WebAppDIRAC/Lib/SessionData.py
+++ b/src/WebAppDIRAC/Lib/SessionData.py
@@ -125,14 +125,6 @@ class SessionData(object):
 
         :return: str
     """
-    if not cls.__extVersion:
-      extPath = os.path.join(cls.getWebAppPath(), "static", "extjs")
-      extVersionPath = []
-      for entryName in os.listdir(extPath):
-        if entryName.find("ext-") == 0:
-          extVersionPath.append(entryName)
-
-      cls.__extVersion = sorted(extVersionPath)[-1]
     return cls.__extVersion
 
   @classmethod


### PR DESCRIPTION
This code has been unused for over three years (since https://github.com/DIRACGrid/WebAppDIRAC/commit/6870bf9dc34c294f74a2c4df72cc1cbb6ec2746a) and even if it was used it wouldn't work any more as a `ext-X.Y.Z` folder is no longer distributed.