### PR TITLE
[v4r2] consider VO and setup settings

### DIFF
--- a/WebApp/static/core/js/core/App.js
+++ b/WebApp/static/core/js/core/App.js
@@ -284,8 +284,6 @@ Ext.define("Ext.dirac.core.App", {
             The optional 'Z' part denotes the time zone in the format +-hh:mm. A single letter Z would mean UTC+0.
             Shorter variants are also possible, like YYYY-MM-DDTHH:mm, YYYY-MM-DD or YYYY-MM or even YYYY.
         */
-
-
         return !downtime.end ? {} : ((!downtime.start || now > Date.parse(downtime.start)) && now < Date.parse(downtime.end)) ? downtime : {};
       } else {
         return {}

--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ import os
 
 majorVersion = 4
 minorVersion = 2
-patchLevel = 4
+patchLevel = 5
 preVersion = 0
 
 version = "v%sr%s" % (majorVersion, minorVersion)

--- a/release.notes
+++ b/release.notes
@@ -1,3 +1,9 @@
+[v4r2p5]
+
+CHANGE: (#506) change datetime field behavior in selector, use Time field
+CHANGE: (#505) get hosts from DB for SystemAdministrator
+NEW: (#503) declare downtime for the application
+
 [v4r2p4]
 
 FIX: (#495) copy SettingsPanel.js to desktop folder


### PR DESCRIPTION
NOTE: this PR wait [#5262](https://github.com/DIRACGrid/DIRAC/pull/5262)

With these changes, the WebApp section can contain a configuration for each setup or VO, as organized in Operations:
```
Operations
{
  myVO
  {
    WebApp
    {
      Option = myVO_bla
      Schema
      { ... }
    }
  }
  mySetup
  {
    WebApp
    {
      Option = mySetup_bla
    }
  }
}
WebApp
{
  Option = some_value
  Schema
  { ... }
}
```

BEGINRELEASENOTES
This changes consider VO and setup settings in `/WebApp` section.

CHANGE: consider VO and setup settings

ENDRELEASENOTES
