### PR TITLE
[v4r3] Create StaticResourceLinkDir if it doesn't exist

### DIFF
--- a/src/WebAppDIRAC/scripts/dirac_webapp_run.py
+++ b/src/WebAppDIRAC/scripts/dirac_webapp_run.py
@@ -26,6 +26,8 @@ def _createStaticSymlinks(targetDir):
 
   :params str targetDir: The directory in which to create the symlinks
   """
+  if not os.path.isdir(targetDir):
+    os.makedirs(targetDir)
   extensions = extensionsByPriority()
   for extension in extensions:
     if six.PY3:


### PR DESCRIPTION

BEGINRELEASENOTES

FIX: Create the directory in /WebApp/StaticResourceLinkDir if it doesn't already exist

ENDRELEASENOTES
