### PR TITLE
[v4r3] use default menu if Schema not set

### DIFF
--- a/src/WebAppDIRAC/Lib/SessionData.py
+++ b/src/WebAppDIRAC/Lib/SessionData.py
@@ -150,17 +150,16 @@ class SessionData(object):
 
         :return: list
     """
+    menuSection = "%s/Schema" % (Conf.BASECS)
     # Somebody coming from HTTPS and not with a valid group
     group = self.__credDict.get("group", "")
     # Cache time!
     if group not in self.__groupMenu:
-      result = gConfig.getSections(Conf.BASECS)
-      if not result['OK']:
-        return result
-      if "Schema" not in result['Value']:
+      result = gConfig.getSections(menuSection)
+      if not result['OK'] or not result['Value']:
         self.__groupMenu[group] = self.__generateDefaultSchema()
       else:
-        self.__groupMenu[group] = self.__generateSchema("%s/Schema" % (Conf.BASECS), "")
+        self.__groupMenu[group] = self.__generateSchema(menuSection, "")
     return self.__groupMenu[group]
 
   @classmethod

--- a/src/WebAppDIRAC/Lib/SessionData.py
+++ b/src/WebAppDIRAC/Lib/SessionData.py
@@ -16,33 +16,33 @@ from WebAppDIRAC.Lib import Conf
 __RCSID__ = "$Id$"
 
 DEFAULT_SCHEMA = [
-  ["Tools", [
-    ["app", "Application Wizard", "DIRAC.ApplicationWizard"],
-    ["app", "Job Launchpad", "DIRAC.JobLaunchpad"],
-    ["app", "Notepad", "DIRAC.Notepad"],
-    ["app", "Proxy Upload", "DIRAC.ProxyUpload"]
-  ]],
-  ["Applications", [
-    ["app", "Accounting", "DIRAC.Accounting"],
-    ["app", "Activity Monitor", "DIRAC.ActivityMonitor"],
-    ["app", "Configuration Manager", "DIRAC.ConfigurationManager"],
-    ["app", "Job Monitor", "DIRAC.JobMonitor"],
-    ["app", "Downtimes", "DIRAC.Downtimes"],
-    ["app", "File Catalog", "DIRAC.FileCatalog"],
-    ["app", "Job Monitor", "DIRAC.JobMonitor"],
-    ["app", "Job Summary", "DIRAC.JobSummary"],
-    ["app", "Pilot Monitor", "DIRAC.PilotMonitor"],
-    ["app", "Pilot Summary", "DIRAC.PilotSummary"],
-    ["app", "Proxy Manager", "DIRAC.ProxyManager"],
-    ["app", "Public State Manager", "DIRAC.PublicStateManager"],
-    ["app", "Registry Manager", "DIRAC.RegistryManager"],
-    ["app", "Request Monitor", "DIRAC.RequestMonitor"],
-    ["app", "Resource Summary", "DIRAC.ResourceSummary"],
-    ["app", "Site Summary", "DIRAC.SiteSummary"],
-    ["app", "Space Occupancy", "DIRAC.SpaceOccupancy"],
-    ["app", "System Administration", "DIRAC.SystemAdministration"],
-    ["app", "Transformation Monitor", "DIRAC.TransformationMonitor"]
-  ]]
+    ["Tools", [
+        ["app", "Application Wizard", "DIRAC.ApplicationWizard"],
+        ["app", "Job Launchpad", "DIRAC.JobLaunchpad"],
+        ["app", "Notepad", "DIRAC.Notepad"],
+        ["app", "Proxy Upload", "DIRAC.ProxyUpload"]
+    ]],
+    ["Applications", [
+        ["app", "Accounting", "DIRAC.Accounting"],
+        ["app", "Activity Monitor", "DIRAC.ActivityMonitor"],
+        ["app", "Configuration Manager", "DIRAC.ConfigurationManager"],
+        ["app", "Job Monitor", "DIRAC.JobMonitor"],
+        ["app", "Downtimes", "DIRAC.Downtimes"],
+        ["app", "File Catalog", "DIRAC.FileCatalog"],
+        ["app", "Job Monitor", "DIRAC.JobMonitor"],
+        ["app", "Job Summary", "DIRAC.JobSummary"],
+        ["app", "Pilot Monitor", "DIRAC.PilotMonitor"],
+        ["app", "Pilot Summary", "DIRAC.PilotSummary"],
+        ["app", "Proxy Manager", "DIRAC.ProxyManager"],
+        ["app", "Public State Manager", "DIRAC.PublicStateManager"],
+        ["app", "Registry Manager", "DIRAC.RegistryManager"],
+        ["app", "Request Monitor", "DIRAC.RequestMonitor"],
+        ["app", "Resource Summary", "DIRAC.ResourceSummary"],
+        ["app", "Site Summary", "DIRAC.SiteSummary"],
+        ["app", "Space Occupancy", "DIRAC.SpaceOccupancy"],
+        ["app", "System Administration", "DIRAC.SystemAdministration"],
+        ["app", "Transformation Monitor", "DIRAC.TransformationMonitor"]
+    ]]
 ]
 
 class SessionData(object):

--- a/src/WebAppDIRAC/Lib/SessionData.py
+++ b/src/WebAppDIRAC/Lib/SessionData.py
@@ -140,7 +140,7 @@ class SessionData(object):
         if self.__isGroupAuthApp(app[-1]):
           appList.append(app)
       if appList:
-        schema.append(section, appList)
+        schema.append((section, appList))
     return schema
 
   def __getGroupMenu(self):


### PR DESCRIPTION
If `/WebApp/Schema` does not exist default schema will taken:
```
DEFAULT_SCHEMA = [
  ["Tools", [
    ["app", "Application Wizard", "DIRAC.ApplicationWizard"],
    ["app", "Job Launchpad", "DIRAC.JobLaunchpad"],
    ["app", "Notepad", "DIRAC.Notepad"],
    ["app", "Proxy Upload", "DIRAC.ProxyUpload"]
  ]],
  ["Applications", [
    ["app", "Accounting", "DIRAC.Accounting"],
    ["app", "Activity Monitor", "DIRAC.ActivityMonitor"],
    ["app", "Configuration Manager", "DIRAC.ConfigurationManager"],
    ["app", "Job Monitor", "DIRAC.JobMonitor"],
    ["app", "Downtimes", "DIRAC.Downtimes"],
    ["app", "File Catalog", "DIRAC.FileCatalog"],
    ["app", "Job Monitor", "DIRAC.JobMonitor"],
    ["app", "Job Summary", "DIRAC.JobSummary"],
    ["app", "Pilot Monitor", "DIRAC.PilotMonitor"],
    ["app", "Pilot Summary", "DIRAC.PilotSummary"],
    ["app", "Proxy Manager", "DIRAC.ProxyManager"],
    ["app", "Public State Manager", "DIRAC.PublicStateManager"],
    ["app", "Registry Manager", "DIRAC.RegistryManager"],
    ["app", "Request Monitor", "DIRAC.RequestMonitor"],
    ["app", "Resource Summary", "DIRAC.ResourceSummary"],
    ["app", "Site Summary", "DIRAC.SiteSummary"],
    ["app", "Space Occupancy", "DIRAC.SpaceOccupancy"],
    ["app", "System Administration", "DIRAC.SystemAdministration"],
    ["app", "Transformation Monitor", "DIRAC.TransformationMonitor"]
  ]]
]
```

The idea is to install WebApp with minimal intervention in `dirac.cfg` and then configure it from the web interface.

BEGINRELEASENOTES

NEW: use default menu for fresh WebApp installation

ENDRELEASENOTES
