### PR TITLE
[v4r3] Use lists instead of tuples in VMDiracHandler

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/VMDiracHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/VMDiracHandler.py
@@ -35,7 +35,7 @@ class VMDiracHandler(WebHandler):
       sortValue = ast.literal_eval(sortValue.strip("[]"))
       sortField = str(sortValue["property"]).replace("_", ".")
       sortDir = str(sortValue["direction"])
-    sort = [(sortField, sortDir)]
+    sort = [[sortField, sortDir]]
 
     condDict = {}
     if 'cond' in self.request.arguments:


### PR DESCRIPTION
BEGINRELEASE

FIX: Use lists instead of tuples in VMDiracHandler

ENDRELEASE