### PR TITLE
[v5r0] use BaseRequestHandler for FileCatalog

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/FileCatalogHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/FileCatalogHandler.py
@@ -4,41 +4,45 @@ import random
 import shutil
 import zipfile
 
-from hashlib import md5
-
-from DIRAC import gConfig, gLogger
+from DIRAC import gLogger, S_ERROR, S_OK
 from DIRAC.Core.Utilities import Time
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 
-from WebAppDIRAC.Lib.WebHandler import WebHandler, asyncGen
+from WebAppDIRAC.Lib.WebHandler import _WebHandler as WebHandler, FileResponse
 
 
 class FileCatalogHandler(WebHandler):
 
-    AUTH_PROPS = "authenticated"
+    DEFAULT_AUTHORIZATION = "authenticated"
+
+    # Supported operands
+    __operands = ["in", "nin", "=", "!=", ">=", "<=", ">", "<"]
 
     def initializeRequest(self):
+        """Called at every request, may be overwritten in your handler."""
         self.user = self.getUserName()
         self.group = self.getUserGroup()
         self.vo = getVOForGroup(self.group)
         self.fc = FileCatalog(vo=self.vo)
 
-    @asyncGen
-    def web_getSelectedFiles(self):
-        """Method to get the selected file(s)"""
-        gLogger.always("getSelectedFiles: incoming arguments", repr(self.request.arguments))
+    def web_getSelectedFiles(self, archivePath=None, path=None):
+        """Method to get the selected file(s)
 
+        :param str archivePath: archive path
+        :param str path: path LFN
+
+        :return: dict
+        """
         # First pass: download files and check for the success
-        if "archivePath" not in self.request.arguments:
+        if not archivePath:
             tmpdir = "/tmp/" + str(time.time()) + str(random.random())
             dataMgr = DataManager(vo=self.vo)
-            lfnStr = self.get_argument("path")
             if not os.path.isdir(tmpdir):
                 os.makedirs(tmpdir)
             os.chdir(tmpdir)
-            for lfn in lfnStr.split(","):
+            for lfn in path.split(","):
                 gLogger.always("Data manager get file %s" % lfn)
                 last_slash = lfn.rfind("/")
                 pos_relative = lfn.find("/")
@@ -53,9 +57,8 @@ class FileCatalogHandler(WebHandler):
                 result = dataMgr.getFile(str(lfn), destinationDir=str(tmpPathInZip))
                 if not result["OK"]:
                     gLogger.error("Error getting while getting files", result["Message"])
-                    self.finish({"success": "false", "error": result["Message"], "lfn": lfn})
                     shutil.rmtree(tmpdir)
-                    return
+                    return {"success": "false", "error": result["Message"], "lfn": lfn}
 
             # make zip file
             zipname = tmpdir.split("/")[-1] + ".zip"
@@ -78,64 +81,47 @@ class FileCatalogHandler(WebHandler):
                     zFile.write(os.path.join(absolutePath, filename))
             zFile.close()
             shutil.rmtree(tmpdir)
-            self.finish({"success": "true", "archivePath": archivePath})
+            return {"success": "true", "archivePath": archivePath}
 
-        else:
-            # Second pass: deliver the requested archive
-            archivePath = self.get_argument("archivePath")
-            # read zip file
-            with open(archivePath, "rb") as archive:
-                data = archive.read()
-            # cleanup
-            os.remove(archivePath)
+        # Second pass: deliver the requested archive
+        # read zip file
+        with open(archivePath, "rb") as archive:
+            data = archive.read()
+        # cleanup
+        os.remove(archivePath)
+        return FileResponse(data, os.path.basename(archivePath))
 
-            self.set_header("Content-type", "text/plain")
-            self.set_header("Content-Length", len(data))
-            self.set_header("Content-Disposition", 'attachment; filename="' + os.path.basename(archivePath))
-
-            self.finish(data)
-
-    @asyncGen
     def web_getMetadataFields(self):
-        """Method to read all the available fields possible for defining a query"""
-        self.L_NUMBER = 0
-        self.S_NUMBER = 0
-        result = yield self.threadTask(self.fc.getMetadataFields)
-        gLogger.debug("request: %s" % result)
-        if not result["OK"]:
-            gLogger.error("getSelectorGrid: %s" % result["Message"])
-            self.finish({"success": "false", "error": result["Message"]})
-            return
-        result = result["Value"]
+        """Method to read all the available fields possible for defining a query
+
+        :return: dict
+        """
         callback = {}
-        if "FileMetaFields" not in result:
-            error = "Service response has no FileMetaFields key"
-            gLogger.error("getSelectorGrid: %s" % error)
-            self.finish({"success": "false", "error": error})
-            return
-        if "DirectoryMetaFields" not in result:
-            error = "Service response has no DirectoryMetaFields key"
-            gLogger.error("getSelectorGrid: %s" % error)
-            self.finish({"success": "false", "error": error})
-            return
-        filemeta = result["FileMetaFields"]
+        result = self.__getMetadataFields()
+        if not result["OK"]:
+            gLogger.error(result["Message"])
+            return {"success": "false", "error": result["Message"]}
+        filemeta, dirmeta = result["Value"]
         if len(filemeta) > 0:
-            for key, value in filemeta.items():
+            for key in filemeta:
                 callback[key] = "label"
         gLogger.debug("getSelectorGrid: FileMetaFields callback %s" % callback)
-        dirmeta = result["DirectoryMetaFields"]
         if len(dirmeta) > 0:
-            for key, value in dirmeta.items():
-                callback[key] = value.lower()
+            for key in dirmeta:
+                callback[key] = dirmeta[key].lower()
         gLogger.debug("getSelectorGrid: Resulting callback %s" % callback)
-        self.finish({"success": "true", "result": callback})
+        return {"success": "true", "result": callback}
 
-    @asyncGen
-    def web_getQueryData(self):
-        """Method to read all the available options for a metadata field"""
+    def web_getQueryData(self, path="/", **kwargs):
+        """Method to read all the available options for a metadata field
+
+        :param str path: path LFN
+
+        :return: dict
+        """
         try:
             compat = {}
-            for key in self.request.arguments:
+            for key in kwargs:
                 parts = key.split(".")
                 if len(parts) != 3:
                     continue
@@ -144,7 +130,7 @@ class FileCatalogHandler(WebHandler):
                 if not name:
                     continue
 
-                value = self.get_argument(key).split("|")
+                value = kwargs[key].split("|")
 
                 # check existence of the 'name' section
                 if name not in compat:
@@ -162,59 +148,86 @@ class FileCatalogHandler(WebHandler):
                 elif value[0] == "s":
                     compat[name][sign] += value[1].split(":::")
 
-        except Exception:
-            self.finish({"success": "false", "error": "Metadata query error"})
-            return
-
-        path = "/"
-
-        if "path" in self.request.arguments:
-            path = self.get_argument("path")
+        except Exception as e:
+            return {"success": "false", "error": "Metadata query error: %s" % repr(e)}
 
         gLogger.always(compat)
 
-        result = yield self.threadTask(self.fc.getCompatibleMetadata, compat, path)
+        result = self.fc.getCompatibleMetadata(compat, path)
         gLogger.always(result)
 
         if not result["OK"]:
-            self.finish({"success": "false", "error": result["Message"]})
-            return
+            return {"success": "false", "error": result["Message"]}
+        return {"success": "true", "result": result["Value"]}
 
-        self.finish({"success": "true", "result": result["Value"]})
+    def web_getFilesData(self, limit=25, start=0, path=None, **kwargs):
+        """Get files data
 
-    @asyncGen
-    def web_getFilesData(self):
-        req = self.__request()
-        gLogger.always(req)
+        :param int limit: limit
+        :param int start: start
+        :param str path: path
+
+        :return: dict
+        """
+        req = {"selection": {}, "path": "/"}
+
+        result = self.__getMetadataFields()
+        if not result["OK"]:
+            gLogger.error("request: %s" % result["Message"])
+        else:
+            filemeta, dirmeta = result["Value"]
+            meta = [k for k in dirmeta]
+            gLogger.always("request: metafields: %s " % meta)
+
+            for param in kwargs:
+                tmp = param.split(".")
+                if len(tmp) != 3:
+                    continue
+                _, name, logic = tmp
+                value = kwargs[param].split("|")
+                if logic not in self.__operands:
+                    gLogger.always("Operand '%s' is not supported " % logic)
+                    continue
+
+                if name in meta:
+                    # check existence of the 'name' section
+                    if name not in req["selection"]:
+                        req["selection"][name] = {}
+
+                    # check existence of the 'sign' section
+                    if logic not in req["selection"][name]:
+                        if value[0] == "v":
+                            req["selection"][name][logic] = ""
+                        elif value[0] == "s":
+                            req["selection"][name][logic] = []
+
+                    if value[0] == "v":
+                        req["selection"][name][logic] = value[1]
+                    elif value[0] == "s":
+                        req["selection"][name][logic] += value[1].split(":::")
+            if path:
+                req["path"] = path
+
         gLogger.debug("submit: incoming request %s" % req)
-        result = yield self.threadTask(
-            self.fc.findFilesByMetadataWeb, req["selection"], req["path"], self.S_NUMBER, self.L_NUMBER
-        )
+        result = self.fc.findFilesByMetadataWeb(req["selection"], req["path"], start, limit)
         gLogger.debug("submit: result of findFilesByMetadataDetailed %s" % result)
         if not result["OK"]:
             gLogger.error("submit: %s" % result["Message"])
-            self.finish({"success": "false", "error": result["Message"]})
-            return
+            return {"success": "false", "error": result["Message"]}
         result = result["Value"]
 
         if not len(result) > 0:
-            self.finish({"success": "true", "result": [], "total": 0, "date": "-"})
-            return
+            return {"success": "true", "result": [], "total": 0, "date": "-"}
 
         total = result["TotalRecords"]
         result = result["Records"]
 
         callback = list()
-        for key, value in result.items():
+        for key in result:
+            value = result[key]
 
-            size = ""
-            if "Size" in value:
-                size = value["Size"]
-
-            date = ""
-            if "CreationDate" in value:
-                date = str(value["CreationDate"])
-
+            size = value["Size"] if "Size" in value else ""
+            date = str(value["CreationDate"]) if "CreationDate" in value else ""
             meta = ""
             if "Metadata" in value:
                 m = value["Metadata"]
@@ -235,191 +248,85 @@ class FileCatalogHandler(WebHandler):
                 }
             )
         timestamp = Time.dateTime().strftime("%Y-%m-%d %H:%M [UTC]")
-        self.finish({"success": "true", "result": callback, "total": total, "date": timestamp})
+        return {"success": "true", "result": callback, "total": total, "date": timestamp}
 
-    def __request(self):
+    def web_getMetadataFilesInFile(self, selection="", path=None):
+        """Get metadata files
+
+        :param str selection: selection
+        :param str path: path
+
+        :return: dict
+        """
         req = {"selection": {}, "path": "/"}
-
-        self.L_NUMBER = 25
-        if "limit" in self.request.arguments and len(self.get_argument("limit")) > 0:
-            self.L_NUMBER = int(self.get_argument("limit"))
-
-        self.S_NUMBER = 0
-        if "start" in self.request.arguments and len(self.get_argument("start")) > 0:
-            self.S_NUMBER = int(self.get_argument("start"))
-
-        result = gConfig.getOption("/WebApp/ListSeparator")
-        if result["OK"]:
-            separator = result["Value"]
+        result = self.__getMetadataFields()
+        if not result["OK"]:
+            gLogger.error("request: %s" % result["Message"])
         else:
-            separator = ":::"
+            filemeta, dirmeta = result["Value"]
+            meta = [k for k in dirmeta]
+            gLogger.always("request: metafields: %s " % meta)
 
-        result = self.fc.getMetadataFields()
-        gLogger.debug("request: %s" % result)
+            selectionElems = selection.split("<|>")
 
-        if not result["OK"]:
-            gLogger.error("request: %s" % result["Message"])
-            return req
-        result = result["Value"]
+            gLogger.always("request: THISSSS %s " % selection)
 
-        if "FileMetaFields" not in result:
-            error = "Service response has no FileMetaFields key. Return empty dict"
-            gLogger.error("request: %s" % error)
-            return req
+            for param in selectionElems:
+                tmp = str(param).split("|")
 
-        if "DirectoryMetaFields" not in result:
-            error = "Service response has no DirectoryMetaFields key. Return empty dict"
-            gLogger.error("request: %s" % error)
-            return req
+                if len(tmp) != 4:
+                    continue
 
-        filemeta = result["FileMetaFields"]
-        dirmeta = result["DirectoryMetaFields"]
+                name = tmp[0]
+                logic = tmp[1]
 
-        meta = []
-        for key, value in dirmeta.items():
-            meta.append(key)
+                if logic not in self.__operands:
+                    gLogger.always("Operand '%s' is not supported " % logic)
+                    continue
 
-        gLogger.always("request: metafields: %s " % meta)
+                if name in meta:
+                    # check existence of the 'name' section
+                    if name not in req["selection"]:
+                        req["selection"][name] = dict()
 
-        for param in self.request.arguments:
-            tmp = param.split(".")
-            if len(tmp) != 3:
-                continue
-            _, name, logic = tmp
-            value = self.get_argument(param).split("|")
-            if logic not in ["in", "nin", "=", "!=", ">=", "<=", ">", "<"]:
-                gLogger.always("Operand '%s' is not supported " % logic)
-                continue
+                    # check existence of the 'sign' section
+                    if logic not in req["selection"][name]:
+                        if tmp[2] == "v":
+                            req["selection"][name][logic] = ""
+                        elif tmp[2] == "s":
+                            req["selection"][name][logic] = []
 
-            if name in meta:
-                # check existence of the 'name' section
-                if name not in req["selection"]:
-                    req["selection"][name] = {}
-
-                # check existence of the 'sign' section
-                if logic not in req["selection"][name]:
-                    if value[0] == "v":
-                        req["selection"][name][logic] = ""
-                    elif value[0] == "s":
-                        req["selection"][name][logic] = []
-
-                if value[0] == "v":
-                    req["selection"][name][logic] = value[1]
-                elif value[0] == "s":
-                    req["selection"][name][logic] += value[1].split(":::")
-        if "path" in self.request.arguments:
-            req["path"] = self.get_argument("path")
-        gLogger.always("REQ: ", req)
-        return req
-
-    def __request_file(self):
-        req = {"selection": {}, "path": "/"}
-
-        separator = ":::"
-
-        result = self.fc.getMetadataFields()
-        gLogger.debug("request: %s" % result)
-
-        if not result["OK"]:
-            gLogger.error("request: %s" % result["Message"])
-            return req
-        result = result["Value"]
-
-        if "FileMetaFields" not in result:
-            error = "Service response has no FileMetaFields key. Return empty dict"
-            gLogger.error("request: %s" % error)
-            return req
-
-        if "DirectoryMetaFields" not in result:
-            error = "Service response has no DirectoryMetaFields key. Return empty dict"
-            gLogger.error("request: %s" % error)
-            return req
-
-        filemeta = result["FileMetaFields"]
-        dirmeta = result["DirectoryMetaFields"]
-
-        meta = []
-        for key, value in dirmeta.items():
-            meta.append(key)
-
-        gLogger.always("request: metafields: %s " % meta)
-
-        selectionElems = self.get_argument("selection").split("<|>")
-
-        gLogger.always("request: THISSSS %s " % self.get_argument("selection"))
-
-        for param in selectionElems:
-
-            tmp = str(param).split("|")
-
-            if len(tmp) != 4:
-                continue
-
-            name = tmp[0]
-            logic = tmp[1]
-
-            if logic not in ["in", "nin", "=", "!=", ">=", "<=", ">", "<"]:
-                gLogger.always("Operand '%s' is not supported " % logic)
-                continue
-
-            if name in meta:
-                # check existence of the 'name' section
-                if name not in req["selection"]:
-                    req["selection"][name] = dict()
-
-                # check existence of the 'sign' section
-                if logic not in req["selection"][name]:
                     if tmp[2] == "v":
-                        req["selection"][name][logic] = ""
+                        req["selection"][name][logic] = tmp[3]
                     elif tmp[2] == "s":
-                        req["selection"][name][logic] = []
+                        req["selection"][name][logic] += tmp[3].split(":::")
+            if path:
+                req["path"] = path
 
-                if tmp[2] == "v":
-                    req["selection"][name][logic] = tmp[3]
-                elif tmp[2] == "s":
-                    req["selection"][name][logic] += tmp[3].split(":::")
-        if "path" in self.request.arguments:
-            req["path"] = self.get_argument("path")
-        gLogger.always("REQ: ", req)
-        return req
-
-    @asyncGen
-    def web_getMetadataFilesInFile(self):
-        self.set_header("Content-type", "text/plain")
-        self.set_header("Content-Disposition", 'attachment; filename="error.txt"')
-        req = self.__request_file()
-        gLogger.always(req)
         gLogger.debug("submit: incoming request %s" % req)
-        result = yield self.threadTask(self.fc.findFilesByMetadata, req["selection"], req["path"])
-
+        result = self.fc.findFilesByMetadata(req["selection"], req["path"])
         if not result["OK"]:
             gLogger.error("submit: %s" % result["Message"])
-            self.finish({"success": "false", "error": result["Message"]})
-            return
+            return {"success": "false", "error": result["Message"]}
 
-        result = result["Value"]
         retStrLines = []
+        if len(result["Value"]) > 0:
+            retStrLines = [fileName for fileName in result["Value"]]
 
-        if len(result) > 0:
-            for fileName in result:
-                retStrLines.append(fileName)
+        return FileResponse("\n".join(retStrLines), str(req))
 
-        strData = "\n".join(retStrLines)
+    def web_getSubnodeFiles(self, path):
+        """Get subnode files
 
-        self.set_header("Content-type", "text/plain")
-        self.set_header("Content-Disposition", 'attachment; filename="%s.txt"' % md5(str(req).encode()).hexdigest())
-        self.set_header("Content-Length", len(strData))
-        self.finish(strData)
+        :param str path: path
 
-    @asyncGen
-    def web_getSubnodeFiles(self):
-        path = self.get_argument("path")
-
-        result = yield self.threadTask(self.fc.listDirectory, path, False)
+        :return: dict
+        """
+        result = self.fc.listDirectory(path, False)
         if not result["OK"]:
             gLogger.error("submit: %s" % result["Message"])
-            self.finish({"success": "false", "error": result["Message"]})
-            return
+            return {"success": "false", "error": result["Message"]}
+
         filesData = result["Value"]["Successful"][path]["Files"]
         dirData = result["Value"]["Successful"][path]["SubDirs"]
 
@@ -437,5 +344,18 @@ class FileCatalogHandler(WebHandler):
             retData.append(nodeDef)
 
         retData = sorted(retData, key=lambda node: node["text"].upper())
+        return {"success": "true", "nodes": retData}
 
-        self.finish({"success": "true", "nodes": retData})
+    def __getMetadataFields(self):
+        """Helper method to get metadata fields
+
+        :return: S_OK(tuple)/S_ERROR()
+        """
+        result = self.fc.getMetadataFields()
+        if not result["OK"]:
+            return result
+        if "FileMetaFields" not in result["Value"]:
+            return S_ERROR("Service response has no FileMetaFields key. Return empty dict")
+        if "DirectoryMetaFields" not in result["Value"]:
+            return S_ERROR("Service response has no DirectoryMetaFields key. Return empty dict")
+        return S_OK((result["Value"]["FileMetaFields"], result["Value"]["DirectoryMetaFields"]))


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: Use WebHandler with DIRAC.Core.Tornado.Server.privat.BaseRequestHandler for FileCatalog handler.

 ENDRELEASENOTES
