### PR TITLE
[v4r4] Support AccountingMonitor permission

### DIFF
--- a/src/WebAppDIRAC/WebApp/static/core/js/utils/PlotView.js
+++ b/src/WebAppDIRAC/WebApp/static/core/js/utils/PlotView.js
@@ -806,7 +806,15 @@ Ext.define("Ext.dirac.utils.PlotView", {
       oListForGroup.push([oSelectionOptions[i][0], oSelectionOptions[i][0]]);
 
       if (oSelectionOptions[i][0] == "User" || oSelectionOptions[i][0] == "UserGroup") {
-        var allowedProperties = ["CSAdministrator", "JobAdministrator", "JobMonitor", "UserManager", "Operator", "ProductionManagement"];
+        var allowedProperties = [
+          "CSAdministrator",
+          "JobAdministrator",
+          "JobMonitor",
+          "AccountingMonitor",
+          "UserManager",
+          "Operator",
+          "ProductionManagement"
+        ];
         var found = false;
         for (var j = 0; j < allowedProperties.length; j++) {
           // Only


### PR DESCRIPTION
Hi,

This patch simply adds the AccountingMonitor to the list of permissions that get the full filter list in the accounting plots (to match https://github.com/DIRACGrid/DIRAC/pull/5392).

I wasn't sure which versions of WebApp are still supported, but perhaps this could also be backported to all other active versions?

Regards,
Simon

BEGINRELEASENOTES
CHANGE: Enable all filter fields for AccountingMonitor role
ENDRELEASENOTES
