### PR TITLE
[v4r0] Support AccountingMonitor permission(#545)

### DIFF
--- a/WebApp/static/core/js/utils/PlotView.js
+++ b/WebApp/static/core/js/utils/PlotView.js
@@ -906,7 +906,7 @@ Ext.define('Ext.dirac.utils.PlotView', {
           oListForGroup.push([oSelectionOptions[i][0], oSelectionOptions[i][0]]);
 
           if ((oSelectionOptions[i][0] == "User") || (oSelectionOptions[i][0] == "UserGroup")) {
-            var allowedProperties = ["CSAdministrator", "JobAdministrator", "JobMonitor", "UserManager", "Operator", "ProductionManagement"];
+            var allowedProperties = ["CSAdministrator", "JobAdministrator", "JobMonitor", "AccountingMonitor", "UserManager", "Operator", "ProductionManagement"];
             var found = false;
             for (var j = 0; j < allowedProperties.length; j++) { // Only
               // powerfull


### PR DESCRIPTION
BEGINRELEASENOTES

Provide #545 change to v4r0+.

CHANGE: allow AccountingMonitor to get the full filter list in the accounting plots

ENDRELEASENOTES
