### PR TITLE
[v4r3] Increase client.updateSoftware timeout

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/SystemAdministrationHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/SystemAdministrationHandler.py
@@ -194,7 +194,7 @@ class SystemAdministrationHandler(WebHandler):
       elif action == "revert":
         result = yield self.threadTask(client.revertSoftware)
       elif action == "update":
-        result = yield self.threadTask(client.updateSoftware, version, '', '', timeout=300)
+        result = yield self.threadTask(client.updateSoftware, version, '', '', timeout=600)
       else:
         error = i + ": Action %s is not defined" % action
         actionFailed.append(error)


### PR DESCRIPTION
The call takes about 305 seconds in certification making it a little flakey.

BEGINRELEASENOTES

FIX: Increase client.updateSoftware timeout

ENDRELEASENOTES
