### PR TITLE
[5.0] use arguments without '_' prefix

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/MonitoringHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/MonitoringHandler.py
@@ -90,8 +90,6 @@ class MonitoringHandler(WebHandler):
     pinDates = False
 
     for name in self.request.arguments:
-      if name.find("_") != 0:
-        continue
       pD[name[1:]] = self.get_argument(name)
 
     # Personalized title?


### PR DESCRIPTION
The end of the change initiated by #539.

BEGINRELEASENOTES

FIX: use arguments without '_' prefix, continue #539 PR

ENDRELEASENOTES
