### PR TITLE
[5.0] use full name of the incoming argument (hackathon fixes)

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/MonitoringHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/MonitoringHandler.py
@@ -91,7 +91,7 @@ class MonitoringHandler(WebHandler):
         pinDates = False
 
         for name in self.request.arguments:
-            pD[name[1:]] = self.get_argument(name)
+            pD[name] = self.get_argument(name)
 
         # Personalized title?
         if "plotTitle" in pD:


### PR DESCRIPTION

BEGINRELEASENOTES

FIX: use full name of the incoming argument to Monitoring handler

ENDRELEASENOTES
