### PR TITLE
[5.0] remove Accounting -> Network query (hackathon fixes)

### DIFF
--- a/src/WebAppDIRAC/WebApp/static/DIRAC/Accounting/classes/Accounting.js
+++ b/src/WebAppDIRAC/WebApp/static/DIRAC/Accounting/classes/Accounting.js
@@ -68,15 +68,6 @@ Ext.define("DIRAC.Accounting.classes.Accounting", {
             ["Status", "Status"],
           ],
         },
-        Network: {
-          title: "Network",
-          selectionConditions: [
-            ["Source", "Source Site"],
-            ["Destination", "Destination Site"],
-            ["SourceHostName", "Source Host"],
-            ["DestinationHostName", "Destination Host"],
-          ],
-        },
         StorageOccupancy: {
           title: "Storage Occupancy",
           selectionConditions: [
@@ -129,7 +120,6 @@ Ext.define("DIRAC.Accounting.classes.Accounting", {
         ["WMSHistory", "WMS History"],
         ["Pilot", "Pilot"],
         ["PilotSubmission", "Pilot Submission"],
-        ["Network", "Network"],
         ["StorageOccupancy", "Storage Occupancy"],
       ],
       Monitoring: [


### PR DESCRIPTION
> The network accounting is something that we don't advise to run

BEGINRELEASENOTES

CHANGE: JS: remove Accounting -> Network query


ENDRELEASENOTES
