### PR TITLE
[v4r3] Rename Jobs_Submitted to Jobs_Submitting to follow v7r3 changes

### DIFF
--- a/src/WebAppDIRAC/WebApp/static/DIRAC/TransformationMonitor/classes/TransformationMonitor.js
+++ b/src/WebAppDIRAC/WebApp/static/DIRAC/TransformationMonitor/classes/TransformationMonitor.js
@@ -142,7 +142,7 @@ Ext.define("DIRAC.TransformationMonitor.classes.TransformationMonitor", {
       name: "Jobs_TotalCreated",
     },
     {
-      name: "Jobs_Submitted",
+      name: "Jobs_Submitting",
     },
     {
       name: "Jobs_Waiting",
@@ -273,7 +273,7 @@ Ext.define("DIRAC.TransformationMonitor.classes.TransformationMonitor", {
           "Jobs_Failed",
           "Jobs_Running",
           "Jobs_Stalled",
-          "Jobs_Submitted",
+          "Jobs_Submitting",
           "Jobs_Waiting",
           "Jobs_Completed",
           "Files_PercentProcessed",
@@ -464,8 +464,8 @@ Ext.define("DIRAC.TransformationMonitor.classes.TransformationMonitor", {
         dataIndex: "Jobs_TotalCreated",
         renderFunction: "diffValues",
       },
-      Submitted: {
-        dataIndex: "Jobs_Submitted",
+      Submitting: {
+        dataIndex: "Jobs_Submitting",
         renderFunction: "diffValues",
       },
       Matched: {


### PR DESCRIPTION
Follows the change in https://github.com/DIRACGrid/DIRAC/pull/4903/files#diff-6d18308ca66cd86a5a3780db07da3399db46c6eb2bd31c4aacaccd08c2e6aa9e

BEGINRELEASENOTES

FIX: Show Submitting instead of Submitted in the Transformation Monitor

ENDRELEASENOTES
