### PR TITLE
[sweep:integration] fix: encoding before hashing (py3)

### DIFF
--- a/src/WebAppDIRAC/Lib/WebHandler.py
+++ b/src/WebAppDIRAC/Lib/WebHandler.py
@@ -103,7 +103,7 @@ class FileResponse(TornadoResponse):
             reqObj.set_header("Content-type", "text/plain")
 
         # Generate file name
-        fileName = "%s.%s" % (md5(self.name).hexdigest(), self.ext)
+        fileName = "%s.%s" % (md5(self.name.encode()).hexdigest(), self.ext)
         reqObj.set_header("Content-Disposition", 'attachment; filename="%s"' % fileName)
         reqObj.set_header("Content-Length", len(self.payload))
 

--- a/src/WebAppDIRAC/WebApp/handler/FileCatalogHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/FileCatalogHandler.py
@@ -407,7 +407,7 @@ class FileCatalogHandler(WebHandler):
         strData = "\n".join(retStrLines)
 
         self.set_header("Content-type", "text/plain")
-        self.set_header("Content-Disposition", 'attachment; filename="%s.txt"' % md5(str(req)).hexdigest())
+        self.set_header("Content-Disposition", 'attachment; filename="%s.txt"' % md5(str(req).encode()).hexdigest())
         self.set_header("Content-Length", len(strData))
         self.finish(strData)
 

--- a/src/WebAppDIRAC/WebApp/handler/MonitoringHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/MonitoringHandler.py
@@ -252,8 +252,7 @@ class MonitoringHandler(WebHandler):
             callback = {"success": "false", "error": retVal["Message"]}
             self.finish(callback)
         rawData = retVal["Value"]
-        groupKeys = rawData["data"].keys()
-        groupKeys.sort()
+        groupKeys = sorted(rawData["data"])
         if "granularity" in rawData:
             granularity = rawData["granularity"]
             data = rawData["data"]
@@ -272,7 +271,7 @@ class MonitoringHandler(WebHandler):
             strData = "%s\n" % ",".join(groupKeys)
             strData += ",".join([str(rawData["data"][k]) for k in groupKeys])
         self.set_header("Content-type", "text/csv")
-        self.set_header("Content-Disposition", 'attachment; filename="%s.csv"' % md5(str(params)).hexdigest())
+        self.set_header("Content-Disposition", 'attachment; filename="%s.csv"' % md5(str(params).encode()).hexdigest())
         self.set_header("Content-Length", len(strData))
         self.finish(strData)
 


### PR DESCRIPTION
Sweep #622 `fix: encoding before hashing (py3)` to `integration`.

Adding original author @fstagni as watcher.

BEGINRELEASENOTES

FIX: encoding before hashing (py3)

ENDRELEASENOTES
Closes #624