### PR TITLE
[integration] Fixing bug nomenclature for PilotSubmissionMonitoring

### DIFF
--- a/src/WebAppDIRAC/WebApp/static/DIRAC/Accounting/classes/Accounting.js
+++ b/src/WebAppDIRAC/WebApp/static/DIRAC/Accounting/classes/Accounting.js
@@ -110,7 +110,7 @@ Ext.define("DIRAC.Accounting.classes.Accounting", {
             ["status", "Status"],
           ],
         },
-        PilotMonitoring: {
+        PilotSubmissionMonitoring: {
           title: "Pilot Submission Monitoring",
           selectionConditions: [
             ["HostName", "HostName"],
@@ -137,7 +137,7 @@ Ext.define("DIRAC.Accounting.classes.Accounting", {
         ["WMSHistory", "WMS Monitoring"],
         ["ComponentMonitoring", "Component Monitoring"],
         ["RMSMonitoring", "RMS Monitoring"],
-        ["PilotMonitoring", "Pilot Submission Monitoring"],
+        ["PilotSubmissionMonitoring", "Pilot Submission Monitoring"],
       ],
     };
 


### PR DESCRIPTION
Monitoring of pilot submission was not working on the web app because the nomenclature was wrong. Changed the name to the right one.

BEGINRELEASENOTES

FIX: Changed the nomenclature for PilotSubmissionMonitoring

ENDRELEASENOTES
