### PR TITLE
[integration] Remove x509Chain from the SessionData

### DIFF
--- a/src/WebAppDIRAC/Lib/SessionData.py
+++ b/src/WebAppDIRAC/Lib/SessionData.py
@@ -72,7 +72,10 @@ class SessionData:
                 cls.__extensions.append(cls.__extensions.pop(cls.__extensions.index(ext)))
 
     def __init__(self, credDict, setup):
-        self.__credDict = credDict
+        # Since cece7cc1 in DIRAC the full chain is stored in credDict
+        # This breaks the json.dumps in the various HTML templates so remove it
+        self.__credDict = dict(credDict)
+        self.__credDict.pop("x509Chain", None)
         self.__setup = setup
 
     def __isGroupAuthApp(self, appLoc):


### PR DESCRIPTION
In https://github.com/DIRACGrid/DIRAC/commit/cece7cc189abade5a6f27e772543b601d7517d35 the full chain was added to `credDict`.

The WebApp calls `json.dumps` on the `credDict` in several places which now crashes with `TypeError: Object of type X509Chain is not JSON serializable`.

BEGINRELEASENOTES

FIX: Remove x509Chain from the SessionData

ENDRELEASENOTES
