### PR TITLE
[5.0] fix: JobMonitor page with datetime values

### DIFF
--- a/src/WebAppDIRAC/Lib/WebHandler.py
+++ b/src/WebAppDIRAC/Lib/WebHandler.py
@@ -200,15 +200,6 @@ class _WebHandler(TornadoREST):
         cls.PATH_RE = re.compile(f"{cls.BASE_URL}(.*)")
         return urls
 
-    def finish(self, data=None, *args, **kwargs):
-        """Finishes this response, ending the HTTP request. More detailes:
-        https://www.tornadoweb.org/en/stable/_modules/tornado/web.html#RequestHandler.finish
-        """
-        if data and isinstance(data, dict):
-            self.set_header("Content-Type", "application/json")
-            data = json.dumps(data, default=defaultEncoder)
-        return super().finish(data, *args, **kwargs)
-
     @classmethod
     def _getCSAuthorizarionSection(cls, handler):
         """Search endpoint auth section.
@@ -218,6 +209,16 @@ class _WebHandler(TornadoREST):
         :return: str
         """
         return Conf.getAuthSectionForHandler(handler)
+
+    @staticmethod
+    def encode(inData):
+        """Encode data.
+        The method is defined in BaseRequestHandler and redefined in _WebHandler to provide
+        correct JSON data to the view.
+
+        :return: encoded data
+        """
+        return json.dumps(inData, default=defaultEncoder)
 
     def _getMethodArgs(self, args: tuple, kwargs: dict):
         """Decode args.
@@ -434,6 +435,15 @@ class WebHandler(_WebHandler):
 
         targs = (args, self.__disetDump)
         return IOLoop.current().run_in_executor(gThreadPool, functools.partial(threadJob, *targs, **kwargs))
+
+    def finish(self, data=None, *args, **kwargs):
+        """Finishes this response, ending the HTTP request. More detailes:
+        https://www.tornadoweb.org/en/stable/_modules/tornado/web.html#RequestHandler.finish
+        """
+        if data and isinstance(data, dict):
+            self.set_header("Content-Type", "application/json")
+            data = json.dumps(data, default=defaultEncoder)
+        return super().finish(data, *args, **kwargs)
 
 
 class WebSocketHandler(tornado.websocket.WebSocketHandler, WebHandler):


### PR DESCRIPTION
This PR aims to fix the issue we have on the `JobMonitor` page: datetime values do not appear (`LastUpdate`, `LastSignOfLife` and `SubmissionTime`).

This is a very simple and ugly hack.
We stopped using `WebHandler.finish()` from this commit: https://github.com/DIRACGrid/WebAppDIRAC/commit/3d54ba26574f6b68736aa1a6a1a9188e8524102f.
The method used `defaultEncoder()` to convert `datetime` objects into strings.
Because it is not used anymore, there is no conversion and the webapp is, therefore, not able to interpret the datetime objects.

My guess is that we should probably keep using the `WebHandler.finish` method (https://github.com/DIRACGrid/WebAppDIRAC/blob/c1036c51f8eaea4b99af5be676503673d3acd3ff/src/WebAppDIRAC/Lib/WebHandler.py#L85), or at least part of it related to the `defaultEncoder` method (https://github.com/DIRACGrid/WebAppDIRAC/blob/c1036c51f8eaea4b99af5be676503673d3acd3ff/src/WebAppDIRAC/Lib/WebHandler.py#L54).

Another option would be to convert `datetime` objects into strings within DIRAC before returning a dictionary to the webapp.
This is done in `PilotManagerHandler` (DIRAC) (https://github.com/DIRACGrid/DIRAC/blob/integration/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py#L1155) but not in `JobMonitorHandler` (DIRAC) for instance. Any reason for that?

```python
JobMonitorHandler.getJobPageSummaryWeb() in DIRAC:
datetime.datetime(2021, 8, 18, 14, 42, 16)
PilotManagerHandler.getPilotMonitorWeb() in DIRAC:
'2022-03-24 10:18:14'
```

Any thought about that?

BEGINRELEASENOTES
FIX: JobMonitor page with datetime values
ENDRELEASENOTES
