### PR TITLE
[5.0] Fix name of parameter when changing group

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/RootHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/RootHandler.py
@@ -35,10 +35,10 @@ class RootHandler(WebHandler):
     def __change(self, setup: str = None, group: str = None) -> str:
         """Generate URL to change setup/group"""
         url = f"/{Conf.rootURL().strip('/')}"
-        if group := (group or self.getUserGroup() or "anon"):
-            url += f"/g:{group}"
         if setup := (setup or self.getUserSetup()):
             url += f"/s:{setup}"
+        if group := (group or self.getUserGroup() or "anon"):
+            url += f"/g:{group}"
         if "Referer" in self.request.headers:
             url += f"/?{urlparse(self.request.headers['Referer']).query}"
         return url
@@ -151,10 +151,10 @@ class RootHandler(WebHandler):
                 t.generate(next=authSession["next"], access_token="", message=result["Message"]).decode()
             )
         nextURL = f"/{Conf.rootURL().strip('/')}"
-        if group := result["Value"].get("group"):
-            nextURL += f"/g:{group}"
         if setup := self.getUserSetup():
             nextURL += f"/s:{setup}"
+        if group := result["Value"].get("group"):
+            nextURL += f"/g:{group}"
         nextURL += f"/?{urlparse(authSession['next']).query}"
 
         # Save token and go to main page

--- a/src/WebAppDIRAC/WebApp/handler/RootHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/RootHandler.py
@@ -18,19 +18,19 @@ class RootHandler(WebHandler):
     DEFAULT_LOCATION = "/"
     SUPPORTED_METHODS = ("GET",)
 
-    def web_changeGroup(self, group: str):
+    def web_changeGroup(self, to: str):
         """Change group
 
         :return: TornadoResponse()
         """
-        return TornadoResponse().redirect(self.__change(group=group))  # pylint: disable=no-member
+        return TornadoResponse().redirect(self.__change(group=to))  # pylint: disable=no-member
 
-    def web_changeSetup(self, setup: str):
+    def web_changeSetup(self, to: str):
         """Change setup
 
         :return: TornadoResponse()
         """
-        return TornadoResponse().redirect(self.__change(setup=setup))  # pylint: disable=no-member
+        return TornadoResponse().redirect(self.__change(setup=to))  # pylint: disable=no-member
 
     def __change(self, setup: str = None, group: str = None) -> str:
         """Generate URL to change setup/group"""


### PR DESCRIPTION
```python
Internal Server ErrorTraceback (most recent call last):

  File "/opt/dirac/versions/v11.0.0a2-1653977607/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 649, in executeMethod
    return self.methodObj(*args, **kwargs)

TypeError: web_changeGroup() missing 1 required positional argument: 'group'


During handling of the above exception, another exception occurred:


Traceback (most recent call last):

  File "/opt/dirac/versions/v11.0.0a2-1653977607/Linux-x86_64/lib/python3.9/site-packages/tornado/web.py", line 1704, in _execute
    result = await result

  File "/opt/dirac/versions/v11.0.0a2-1653977607/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 968, in get
    await self.__execute(*args, **kwargs)

  File "/opt/dirac/versions/v11.0.0a2-1653977607/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 921, in __execute
    self.__result = await IOLoop.current().run_in_executor(None, partial(self.executeMethod, args, kwargs))

  File "/opt/dirac/versions/v11.0.0a2-1653977607/Linux-x86_64/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)

  File "/opt/dirac/versions/v11.0.0a2-1653977607/Linux-x86_64/lib/python3.9/site-packages/WebAppDIRAC/Lib/WebHandler.py", line 225, in executeMethod
    return super().executeMethod(args,kwargs)

  File "/opt/dirac/versions/v11.0.0a2-1653977607/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 654, in executeMethod
    raise HTTPError(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))

tornado.web.HTTPError: HTTP 500: Internal Server Error (web_changeGroup() missing 1 required positional argument: 'group')
```


BEGINRELEASENOTES

FIX: Changing group or setup

ENDRELEASENOTES
