### PR TITLE
[5.0] Remove legacy asyncGen function

### DIFF
--- a/src/WebAppDIRAC/Lib/WebHandler.py
+++ b/src/WebAppDIRAC/Lib/WebHandler.py
@@ -102,10 +102,6 @@ def asyncWithCallback(method):
     return tornado.web.asynchronous(method)
 
 
-def asyncGen(method):
-    return gen.coroutine(method)
-
-
 def defaultEncoder(data):
     """Encode
 

--- a/src/WebAppDIRAC/WebApp/handler/RegistryManagerHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/RegistryManagerHandler.py
@@ -1,7 +1,7 @@
 import json
 from diraccfg import CFG
 
-from WebAppDIRAC.Lib.WebHandler import WebSocketHandler, asyncGen
+from WebAppDIRAC.Lib.WebHandler import WebSocketHandler
 from DIRAC.ConfigurationSystem.Client.ConfigurationClient import ConfigurationClient
 from DIRAC import gConfig, gLogger
 from DIRAC.ConfigurationSystem.private.Modificator import Modificator
@@ -14,7 +14,6 @@ class RegistryManagerHandler(WebSocketHandler):
     def on_open(self):
         self.__configData = {}
 
-    @asyncGen
     def on_message(self, msg):
 
         self.log.info(f"RECEIVED {msg}")


### PR DESCRIPTION
No need for release notes as it's already covered as part of the webapp handler modernisation docs.