### PR TITLE
[v5.0] fix (WebSocketHandler): the web socket handler was not setting up the TC

### DIFF
--- a/src/WebAppDIRAC/Lib/WebHandler.py
+++ b/src/WebAppDIRAC/Lib/WebHandler.py
@@ -369,3 +369,15 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler, WebHandler):
     def _getMethod(self):
         """Get method function to call."""
         return self.on_open
+
+    def _on_message(self, msg):
+        """This needs to be implemented instead of ``on_message``"""
+        raise NotImplementedError('"_on_message" method is not implemented')
+
+    def on_message(self, msg):
+        """Setup the threadConfig before doing the actual calls.
+        Developer should implement ``_on_message`` instead
+        of ``on_message``
+        """
+        with self._setupThreadConfig():
+            return self._on_message(msg)

--- a/src/WebAppDIRAC/WebApp/handler/ConfigurationManagerHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/ConfigurationManagerHandler.py
@@ -18,7 +18,7 @@ class ConfigurationManagerHandler(WebSocketHandler):
     def on_open(self):
         self.__configData = {}
 
-    def on_message(self, msg):
+    def _on_message(self, msg):
         self.log.debug("RECEIVED", msg)
         try:
             params = json.loads(msg)

--- a/src/WebAppDIRAC/WebApp/handler/RegistryManagerHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/RegistryManagerHandler.py
@@ -14,7 +14,7 @@ class RegistryManagerHandler(WebSocketHandler):
     def on_open(self):
         self.__configData = {}
 
-    def on_message(self, msg):
+    def _on_message(self, msg):
 
         self.log.info(f"RECEIVED {msg}")
         try:


### PR DESCRIPTION
All CS and Registry were executed using the host certificate. VERY nice loophole :-) 



BEGINRELEASENOTES

FIX: WebSocketHandler sets the ThreadConfig before calling on_message

ENDRELEASENOTES
