### PR TITLE
fix (UPHandler): use correct web method when listing public states

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/UPHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/UPHandler.py
@@ -217,7 +217,7 @@ class UPHandler(WebHandler):
         user = self.getUserName()
 
         up = UserProfileClient(f"Web/{obj}/{app}")
-        retVal = up.getUserProfileNames({"PublishAccess": "ALL"})
+        retVal = up.listStatesForWeb({"PublishAccess": "ALL"})
         if not retVal["OK"]:
             raise WErr.fromSERROR(retVal)
         records = retVal["Value"]


### PR DESCRIPTION
fixes the following

```
2023-01-25 08:01:31 UTC WebApp/UPHandler ERROR: Exception serving request string indices must be integers:TypeError('string indices must be integers')
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.1-1674558507/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 649, in _executeMethod
    return self.methodObj(*args, **kwargs)
  File "/opt/dirac/versions/v11.0.1-1674558507/Linux-x86_64/lib/python3.9/site-packages/WebAppDIRAC/WebApp/handler/UPHandler.py", line 263, in web_listPublicStates
    permissions = record["permissions"]
TypeError: string indices must be integers
```

BEGINRELEASENOTES

FIX: UPHandler use correct web method when listing public states

ENDRELEASENOTES
