### PR TITLE
[5.0] fix import of TornadoResponse

### DIFF
--- a/src/WebAppDIRAC/Lib/WebHandler.py
+++ b/src/WebAppDIRAC/Lib/WebHandler.py
@@ -17,7 +17,8 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.JEncode import DATETIME_DEFAULT_FORMAT
 from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
-from DIRAC.Core.Tornado.Server.TornadoREST import TornadoREST, TornadoResponse
+from DIRAC.Core.Tornado.Server.TornadoREST import TornadoREST
+from DIRAC.Core.Tornado.Server.private.BaseRequestHandler import TornadoResponse
 from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import OAuth2Token
 
 from WebAppDIRAC.Lib import Conf


### PR DESCRIPTION
  This is to fix [#6877](https://github.com/DIRACGrid/DIRAC/issues/6877)

BEGINRELEASENOTES

FIX: WebHandler - make explicit import of TornadoResponse from BaseRequestHandler 

ENDRELEASENOTES
