### PR TITLE
Fix Handler component names

### DIFF
--- a/src/WebAppDIRAC/Core/HandlerMgr.py
+++ b/src/WebAppDIRAC/Core/HandlerMgr.py
@@ -100,6 +100,7 @@ class HandlerMgr(metaclass=DIRACSingleton):
 
             # Set the base URL of the request
             handler.BASE_URL = handler_base_url
+            handler._fullComponentName = handler.__name__[: -len("Handler")]
 
             # CHeck it has AUTH_PROPS or DEFAULT_AUTHORIZATION
             if isinstance(handler.AUTH_PROPS, type(None)) and isinstance(handler.DEFAULT_AUTHORIZATION, type(None)):

--- a/src/WebAppDIRAC/Lib/WebHandler.py
+++ b/src/WebAppDIRAC/Lib/WebHandler.py
@@ -159,7 +159,7 @@ class WebHandler(TornadoREST):
         return urls
 
     @classmethod
-    def _getCSAuthorizarionSection(cls, handler):
+    def _getCSAuthorizationSection(cls, handler):
         """Search endpoint auth section.
 
         :param str handler: API name, see :py:meth:`_getFullComponentName`


### PR DESCRIPTION

BEGINRELEASENOTES

FIX: WebHandler - fix typo in the _getCSAuthorizationSection method name
FIX: HandlerMgr - set the _fullComponentName class value

ENDRELEASENOTES
