### PR TITLE
feat: add OwnerGroup to be displayed as a default option

### DIFF
--- a/src/WebAppDIRAC/WebApp/static/DIRAC/JobMonitor/classes/JobMonitor.js
+++ b/src/WebAppDIRAC/WebApp/static/DIRAC/JobMonitor/classes/JobMonitor.js
@@ -516,9 +516,6 @@ Ext.define("DIRAC.JobMonitor.classes.JobMonitor", {
       },
       OwnerGroup: {
         dataIndex: "OwnerGroup",
-        properties: {
-          hidden: true,
-        },
       },
     };
 


### PR DESCRIPTION

BEGINRELEASENOTES
NEW: Added OwnerGroup as a default to JobMonitor to account for the fact that DIRAC will soon be inherently multi-VO and hence the OwnerGroup of the Submitter will matter.
ENDRELEASENOTES
