### PR TITLE
fix: Only auto-reload webapp in development mode

### DIFF
--- a/src/WebAppDIRAC/Core/App.py
+++ b/src/WebAppDIRAC/Core/App.py
@@ -96,12 +96,14 @@ class App:
         SessionData.setHandlers(self.__handlerMgr.getHandlers()["Value"])
         # Create the app
         tLoader = TemplateLoader(self.__handlerMgr.getPaths("template"))
+        debug = Conf.devMode()
+        autoreload = (Conf.numProcesses() < 2) and debug
         kw = dict(
-            debug=Conf.devMode(),
+            debug=debug,
             template_loader=tLoader,
             cookie_secret=str(Conf.cookieSecret()),
             log_function=self._logRequest,
-            autoreload=Conf.numProcesses() < 2,
+            autoreload=autoreload,
         )
 
         # please do no move this lines. The lines must be before the fork_processes


### PR DESCRIPTION
Hi,

The webapp has autoreload enabled if there is only one process: This causes it to stat all of the loaded files (hundreds of them, including all of the python site-package libraries) every second to see if they've changed. In the interests of efficiency, I'd like to suggest that this feature is only enabled in development mode (does anyone actually rely on it for their production instances?). Adding @marianne013 as a watcher.

Regards
Simon

BEGINRELEASENOTES
CHANGE: Only auto-reload webapp code in debug mode
ENDRELEASENOTES
