### PR TITLE
fix: delete proxy without group

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/ProxyManagerHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/ProxyManagerHandler.py
@@ -83,17 +83,8 @@ class ProxyManagerHandler(WebHandler):
         if not (webIds := list(json.loads(idList))):
             return {"success": "false", "error": "No valid id's specified"}
 
-        idList = []
-        for id in webIds:
-            spl = id.split("@")
-            dn = "@".join(spl[:-1])
-            idList.append((dn,))
-        retVal = gProxyManager.deleteProxyBundle(idList)
-        # for uid in webIds:
-        #   spl = uid.split("@")
-        #   dn = "@".join(spl[:-1])
-        #   idList.append(dn)
-        # retVal = yield self.threadTask(ProxyManagerClient().deleteProxy, idList)  # pylint: disable=no-member
+        retVal = gProxyManager.deleteProxyBundle(webIds)
+
         if retVal["OK"]:
             return {"success": "true", "result": retVal["Value"]}
         return {"success": "false", "error": retVal["Message"]}


### PR DESCRIPTION
Related to DIRACGrid/DIRAC#8497

There is still an issue with proxy deletion due to the "@" split, originally designed for DN@Group formatting. 
Since groups are no longer used, this logic incorrectly splits email-style DNs, which prevents correct proxy deletion.

BEGINRELEASENOTES
FIX: Allow deletion of proxies without groups
ENDRELEASENOTES
