### PR TITLE
fix: Correct logic in time selection

### DIFF
--- a/src/WebAppDIRAC/WebApp/static/core/js/utils/DiracTimeSearchPanel.js
+++ b/src/WebAppDIRAC/WebApp/static/core/js/utils/DiracTimeSearchPanel.js
@@ -230,7 +230,7 @@ Ext.define("Ext.dirac.utils.DiracTimeSearchPanel", {
 
     var iSpanValue = me.cmbTimeSpan.getValue();
 
-    if (iSpanValue == null && iSpanValue == 0) {
+    if (iSpanValue == null || iSpanValue == 0) {
       sStartDate = null;
       sStartTime = null;
       sEndDate = null;


### PR DESCRIPTION
Hi,

There is a subtle bug in all of the panels that use time selection; when Time Span "For all time?" is selected, the endTime is mistakenly set to the current time in hours:minutes and included in the request parameters rather than being left blank. This causes things which have changed in the current minute to not be displayed. The root cause of this is a tiny logic bug which means that the wrong path is taken when "For all time" (iSpanValue = 0) is selected.

This visible effect of this was that if you were watching the Job Monitor, for example, jobs which had just started running would "disappear" for up to 60 seconds, until the minute rolled over and then they would reappear.

Regards,
Simon

BEGINRELEASENOTES
FIX: Correct logic in time selection panel
ENDRELEASENOTES
