### PR TITLE
fix: Hide top-level scrollbar on wrongly sized panels

### DIFF
--- a/src/WebAppDIRAC/WebApp/static/core/js/views/tabs/TabPanel.js
+++ b/src/WebAppDIRAC/WebApp/static/core/js/views/tabs/TabPanel.js
@@ -21,7 +21,7 @@ Ext.define("Ext.dirac.views.tabs.TabPanel", {
   renderTo: Ext.getBody(),
   defaults: {
     bodyPadding: 0,
-    scrollable: true,
+    scrollable: false,
   },
   bodyStyle: {
     background: "#AAAAAA",


### PR DESCRIPTION
Hi,

We've found that there is a subtle bug in the webapp layouts on up-to-date Firefox when the page zoom level is set above 100% (specifically tested on 110%). Under these conditions the panel size calculations seem to go off-by-one (a rounding error somewhere?) and extra scrollbars appears at the bottom and side of the tab workspace. The problem is that these "outer" scrollbars cover up the real scrollbars on things like the Job Monitor, which prevents you from seeing all of the columns or scrolling up/down the list of jobs.

To fix this we've just set the TabPanel scrollable default to False to hide the extra scrollbars, this fixes the problem and doesn't have any adverse effects on any of the panels we usually use (it's possible that there is a panel somewhere relying on inheriting scrollable: true; we couldn't find any but they should probably set it explicitly if they need this behaviour).

Regards,
Simon

BEGINRELEASENOTES
FIX: Hide top-level scrollbar on wrongly sized panels
ENDRELEASENOTES
