### PR TITLE
fix: Replace http with https, drop iframe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: eslint
         additional_dependencies:
           - eslint@8.0.1
-          - http://diracproject.web.cern.ch/diracproject/externalLibraries/@sencha_eslint-plugin-extjs.7.0.0.tgz
+          - https://diracproject.web.cern.ch/diracproject/externalLibraries/@sencha_eslint-plugin-extjs.7.0.0.tgz
 
   - repo: https://github.com/ikamensh/flynt/
     rev: "0.77"

--- a/src/WebAppDIRAC/WebApp/static/core/js/views/tabs/RightContainer.js
+++ b/src/WebAppDIRAC/WebApp/static/core/js/views/tabs/RightContainer.js
@@ -97,10 +97,12 @@ Ext.define("Ext.dirac.views.tabs.RightContainer", {
       layout: "fit",
       closable: false,
       xtype: "component",
+      /*
       autoEl: {
         tag: "iframe",
-        src: "http://diracgrid.org",
+        src: "https://diracgrid.org",
       },
+      */
     });
   },
   getStateData: function () {

--- a/src/WebAppDIRAC/WebApp/web.cfg
+++ b/src/WebAppDIRAC/WebApp/web.cfg
@@ -39,7 +39,7 @@ WebApp
 
   Schema
   {
-    Help = link|http://dirac.readthedocs.io/en/latest/UserGuide/index.html
+    Help = link|https://dirac.readthedocs.io/en/latest/UserGuide/index.html
     Tools
     {
       Application Wizard = DIRAC.ApplicationWizard
@@ -71,7 +71,7 @@ WebApp
       #ExampleApp = DIRAC.ExampleApp
     }
 
-    DIRAC = link|http://diracgrid.org
+    DIRAC = link|https://diracgrid.org
   }
 
 }


### PR DESCRIPTION
Hi,

There are a few places in the WebApp where http is used but https would be preferred now.

On of these references is an iframe which loads diracgrid.org behind the webapp every time, but is only actually displayed when the "cog" icon is pressed on the top left menu bar. This has a number of problems: We probably don't want it loading the page every time (extra bloat & latency) and because it was a http iframe it wouldn't load in most browsers in the last 10+ years anyway. For now I've just commented out the iframe entirely: This gives the same "blank page" user experience as we've had forever without the security warning or latency. (Perhaps we could consider removing this tab entirely? It isn't clear where it is specified).

Regards,
Simon

BEGINRELEASENOTES
FIX: Prefer https wherever possible, remove insecure iframe
ENDRELEASENOTES
