### PR TITLE
fix: Add default websocket ping keepalive

### DIFF
--- a/src/WebAppDIRAC/Core/App.py
+++ b/src/WebAppDIRAC/Core/App.py
@@ -104,6 +104,7 @@ class App:
             cookie_secret=str(Conf.cookieSecret()),
             log_function=self._logRequest,
             autoreload=autoreload,
+            websocket_ping_interval=15,
         )
 
         # please do no move this lines. The lines must be before the fork_processes


### PR DESCRIPTION
Hi,

This patch turns on the tornado websocket pings (used for the ConfigurationManager and RegistryManager), which keeps the websocket alive if there are any middleboxes in the way that might close an idle connection.

Regards,
Simon

BEGINRELEASENOTES
FIX: Enabled websocket ping keepalive
ENDRELEASENOTES
