### PR TITLE
fix: Lower log level for KeyError in bulk config get

### DIFF
--- a/src/WebAppDIRAC/WebApp/handler/ConfigurationManagerHandler.py
+++ b/src/WebAppDIRAC/WebApp/handler/ConfigurationManagerHandler.py
@@ -103,8 +103,11 @@ class ConfigurationManagerHandler(WebSocketHandler):
             sectionCfg = self.__configData["cfgData"].getCFG()
             for section in [section for section in sectionPath.split("/") if not section.strip() == ""]:
                 sectionCfg = sectionCfg[section]
-        except Exception as v:
-            self.log.exception("Section does not exist", f"{sectionPath} -> {v!r}")
+        except KeyError as err:
+            self.log.info("Client requested non-existent section", f"{sectionPath} -> {err!r}")
+            return False
+        except Exception as err:
+            self.log.exception("Error loading config section", f"{sectionPath} -> {err!r}")
             return False
 
         for entryName in sectionCfg.listAll():


### PR DESCRIPTION
Hi,

When the admin deletes a config section in ConfigurationManager, it is common for the frontend javascript to then re-request the deleted part of the tree as it re-draws after commit (it's hard to keep track of the full chain of changes in the client code as the admin is free to order them however they want). This doesn't have any negative effects (the rest of the tree is still returned), but results in a full stack trace being logged on the server side: This pull request lowers this to info as it's not an actual problem.

Regards,
Simon

BEGINRELEASENOTES
FIX: Lower log level for KeyError in ConfigManager bulk config get
ENDRELEASENOTES
