### PR TITLE
[v5r0] Replace pkg_resources with importlib

### DIFF
--- a/src/WebAppDIRAC/__init__.py
+++ b/src/WebAppDIRAC/__init__.py
@@ -2,19 +2,16 @@
 """
 
 # Define Version
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.resources
 
 try:
-    __version__ = get_distribution(__name__).version
-    version = __version__
-except DistributionNotFound:
+    version = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
     # package is not installed
     version = "Unknown"
 
 
 def extension_metadata():
-    import importlib.resources  # pylint: disable=import-error,no-name-in-module
-
     return {
         "priority": 10,
         "web_resources": {


### PR DESCRIPTION
Hi,

setuptools >= 82 removed pkg_resources... The webapp is still using this and the problem has started showing up in the v5r0 tests as these use an unpinned version of setuptools (although v6 will ultimately be affected too).

We'll see if this passes the tests in the first instance... Once this is sorted, I'll do a cherry-pick PR onto integration (and then rebase my other PR...).

Regards,
Simon

BEGINRELEASENOTES
FIX: Replace pkg_resources with importlib
ENDRELEASENOTES
