### PR TITLE
[v5r0] Add missing import in __init__

### DIFF
--- a/src/WebAppDIRAC/__init__.py
+++ b/src/WebAppDIRAC/__init__.py
@@ -2,6 +2,7 @@
 """
 
 # Define Version
+import importlib.metadata
 import importlib.resources
 
 try:


### PR DESCRIPTION
It seems I missed an import here; I'm quite surprised it got through pylint without an error, but nothing gets past @marianne013. Will also cherry-pick to integration...

BEGINRELEASENOTES
FIX: Add missing import in __init__
ENDRELEASENOTES
