### PR TITLE
fix: Add missing import in __init__

### DIFF
--- a/src/WebAppDIRAC/__init__.py
+++ b/src/WebAppDIRAC/__init__.py
@@ -2,6 +2,7 @@
 """
 
 # Define Version
+import importlib.metadata
 import importlib.resources
 
 try:


### PR DESCRIPTION
BEGINRELEASENOTES
FIX: Add missing import in __init__
ENDRELEASENOTES
